### PR TITLE
add query parameter nointercept=true

### DIFF
--- a/core/backend/backend.go
+++ b/core/backend/backend.go
@@ -434,18 +434,22 @@ func (b *Backend) hasCollectionOrSingleton(resource string) bool {
 	return ok
 }
 
-func (b *Backend) addChildrenToGetResponse(children []string, r *http.Request, response map[string]interface{}) (int, error) {
+func (b *Backend) addChildrenToGetResponse(children []string, noIntercept bool, r *http.Request, response map[string]interface{}) (int, error) {
 	var all []string
 	for _, child := range children {
 		all = append(all, strings.Split(child, ",")...)
 	}
 	client := client.NewWithRouter(b.router).WithContext(r.Context())
+	options := ""
+	if noIntercept {
+		options = "?nointercept=true"
+	}
 	for _, child := range all {
 		if strings.ContainsRune(child, '/') {
 			return http.StatusBadRequest, fmt.Errorf("invalid child %s", child)
 		}
 		var childJSON map[string]interface{}
-		status, err := client.RawGet(r.URL.Path+"/"+child, &childJSON)
+		status, err := client.RawGet(r.URL.Path+"/"+child+options, &childJSON)
 		if err != nil {
 			return status, fmt.Errorf("cannot get child %s", child)
 		}

--- a/core/backend/doc.go
+++ b/core/backend/doc.go
@@ -211,6 +211,8 @@ a specific user, the user's profile and the user's devices, you can do all that 
 or
 	GET /user?children=profile&children=devices
 
+By using the paramter nointercept=true, it is possible to supress any interceptors and return the latest version of the document stored.
+
 The GET request on collections can be customized with any of the searchable properties, an external index, the ids of
 the resources or the first layer of properties of the json document as a filter. It is possible to search for equality of to search
 a pattern.


### PR DESCRIPTION
this makes it possible to get resources (including children)
in the latest stored version without going through the
possibly costly interceptors