### PR TITLE
make /version accessible to everybody

### DIFF
--- a/core/backend/version.go
+++ b/core/backend/version.go
@@ -32,7 +32,7 @@ func (b *Backend) handleVersion(router *mux.Router) {
 func (b *Backend) versionWithAuth(w http.ResponseWriter, r *http.Request) {
 	if b.authorizationEnabled {
 		auth := access.AuthorizationFromContext(r.Context())
-		if !auth.HasRole("admin") && !auth.HasRole("admin viewer") {
+		if !auth.HasRoles() { // version is authorized to everybody
 			http.Error(w, "not authorized", http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
we need this so that our ci bot ("content manager") can  access /version. It feels unnecessary to put in an extra role for that.