### PR TITLE
fix job handling for long running jobs

### DIFF
--- a/core/access/authorization.go
+++ b/core/access/authorization.go
@@ -32,7 +32,8 @@ const (
 // OnlyAdminAccess requires admin access for everything
 var OnlyAdminAccess bool
 
-/*Authorization is a context object which stores authorization information
+/*
+Authorization is a context object which stores authorization information
 for user, things, or machines.
 
 An authorization carries a list or roles and identifiers of resources from the
@@ -40,11 +41,11 @@ backend configuration. It can also carry additional properties.
 
 Authorizations are added to a request context with
 
-  ctx = auth.ContextWithAuthorization(ctx)
+	ctx = auth.ContextWithAuthorization(ctx)
 
 and retrieved with
 
-  auth := AuthorizationFromContext(ctx)
+	auth := AuthorizationFromContext(ctx)
 
 Authorization objects are added to the context by by different middleware
 implementations, depending on authorization tokens in the HTTP request.
@@ -52,7 +53,6 @@ Kurbisio supports JWT bearer token, Kurbisio-Device-Token,
 Kurbisio-Machine-Token and a pair of Kurbisio-Thing-Key/Kurbisio-Thing-Identifier.
 
 For the benefit of simple frontend development, it also supports a Kurbisio-JWT cookie.
-
 */
 type Authorization struct {
 	Roles     []string          `json:"roles"`
@@ -232,7 +232,7 @@ func HandleAuthorizationRoute(router *mux.Router) {
 	logger.Default().Debugln("authorization")
 	logger.Default().Debugln("  handle route: /authorization GET")
 	router.HandleFunc("/authorization", func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		auth := AuthorizationFromContext(r.Context())
 		if auth == nil {
 			w.WriteHeader(http.StatusNoContent)

--- a/core/backend/backend.go
+++ b/core/backend/backend.go
@@ -44,7 +44,7 @@ var ConfigSchemaJSON string
 
 // InternalDatabaseSchemaVersion is a sequential versioning number of the database schema.
 // If it increases, the backend will try to update the schema.
-const InternalDatabaseSchemaVersion = 2
+const InternalDatabaseSchemaVersion = 3
 
 // Backend is the generic rest backend
 type Backend struct {
@@ -66,8 +66,12 @@ type Backend struct {
 
 	pipelineConcurrency int
 
+	// these queries exist for foreground and background
 	jobsInsertQuery, jobsInsertIfNotExistQuery, jobsCancelQuery,
-	jobsUpdateQuery, jobsDeleteQuery, jobsResetImplicitScheduleQuery, jobsRenewImplicitScheduleQuery, jobsUpdateScheduleQuery, rateLimitQuery string
+	jobsUpdateQuery, jobsDeleteQuery, jobsResetImplicitScheduleQuery,
+	jobsRenewImplicitScheduleQuery, jobsUpdateScheduleQuery [2]string
+
+	rateLimitQuery string
 
 	processJobsAsyncRuns    bool
 	processJobsAsyncTrigger chan struct{}

--- a/core/backend/blob.go
+++ b/core/backend/blob.go
@@ -1071,43 +1071,43 @@ func (b *Backend) createBlobResource(router *mux.Router, rc blobConfiguration) {
 
 	// CREATE
 	router.HandleFunc(listRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		createWithAuth(w, r)
 	}).Methods(http.MethodOptions, http.MethodPost)
 
 	// READ
 	router.HandleFunc(itemRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		readWithAuth(w, r)
 	}).Methods(http.MethodOptions, http.MethodGet)
 
 	// UPDATE / CREATE with in in meta data
 	router.HandleFunc(listRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		upsertWithAuth(w, r)
 	}).Methods(http.MethodOptions, http.MethodPut)
 
 	// LIST
 	router.HandleFunc(listRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		listWithAuth(w, r, nil)
 	}).Methods(http.MethodOptions, http.MethodGet)
 
 	// DELETE
 	router.HandleFunc(itemRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		deleteWithAuth(w, r)
 	}).Methods(http.MethodOptions, http.MethodDelete)
 
 	// CLEAR
 	router.HandleFunc(listRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		clearWithAuth(w, r)
 	}).Methods(http.MethodOptions, http.MethodDelete)
 
 	// UPDATE / CREATE with fully qualified path
 	router.HandleFunc(itemRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		upsertWithAuth(w, r)
 	}).Methods(http.MethodOptions, http.MethodPut)
 }

--- a/core/backend/collection.go
+++ b/core/backend/collection.go
@@ -1878,26 +1878,26 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc collectionConf
 	// CREATE
 	if !singleton {
 		router.Handle(listRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+			logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 			createWithAuth(w, r)
 		}))).Methods(http.MethodOptions, http.MethodPost)
 	}
 
 	// UPDATE/CREATE with id in json
 	router.Handle(listRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		upsertWithAuth(w, r)
 	}))).Methods(http.MethodOptions, http.MethodPut, http.MethodPatch)
 
 	// UPDATE/CREATE with fully qualified path
 	router.Handle(itemRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		upsertWithAuth(w, r)
 	}))).Methods(http.MethodOptions, http.MethodPut, http.MethodPatch)
 
 	// READ
 	router.Handle(itemRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		readWithAuth(w, r)
 	}))).Methods(http.MethodOptions, http.MethodGet)
 
@@ -1906,13 +1906,13 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc collectionConf
 		property := columns[i]
 		propertyRoute := fmt.Sprintf("%s/%s/{%s}", itemRoute, property, property)
 		router.Handle(propertyRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+			logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 			updatePropertyWithAuth(w, r, property)
 		}))).Methods(http.MethodOptions, http.MethodPut)
 		if singleton {
 			propertyRoute := fmt.Sprintf("%s/%s/{%s}", singletonRoute, property, property)
 			router.Handle(propertyRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+				logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 				updatePropertyWithAuth(w, r, property)
 			}))).Methods(http.MethodOptions, http.MethodPut)
 		}
@@ -1920,19 +1920,19 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc collectionConf
 
 	// LIST
 	router.Handle(listRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		listWithAuth(w, r, nil)
 	}))).Methods(http.MethodOptions, http.MethodGet)
 
 	// DELETE
 	router.Handle(itemRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		deleteWithAuth(w, r)
 	}))).Methods(http.MethodOptions, http.MethodDelete)
 
 	// CLEAR
 	router.Handle(listRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		clearWithAuth(w, r)
 	}))).Methods(http.MethodOptions, http.MethodDelete)
 
@@ -1942,20 +1942,20 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc collectionConf
 
 	// READ
 	router.Handle(singletonRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		readWithAuth(w, r)
 
 	}))).Methods(http.MethodOptions, http.MethodGet)
 
 	// UPDATE
 	router.Handle(singletonRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		upsertWithAuth(w, r)
 	}))).Methods(http.MethodOptions, http.MethodPut, http.MethodPatch)
 
 	// DELETE
 	router.Handle(singletonRoute, handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		deleteWithAuth(w, r)
 	}))).Methods(http.MethodOptions, http.MethodDelete)
 

--- a/core/backend/cors.go
+++ b/core/backend/cors.go
@@ -22,7 +22,7 @@ func (b *Backend) handleCORS() {
 			w.Header().Set("Access-Control-Expose-Headers", "*")
 
 			if r.Method == http.MethodOptions {
-				logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method, " (handled by CORS middleware)")
+				logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method, " (handled by CORS middleware)")
 				w.WriteHeader(http.StatusOK)
 				return
 			}

--- a/core/backend/jobs.go
+++ b/core/backend/jobs.go
@@ -184,16 +184,16 @@ WHERE serial = $1 RETURNING serial;`
 	logger.Default().Debugln("  handle route: /kurbisio/events PUT")
 
 	router.HandleFunc("/kurbisio/events/{event}", func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		b.eventsWithAuth(w, r)
 	}).Methods(http.MethodOptions, http.MethodPut)
 
 	router.HandleFunc("/kurbisio/health", func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		b.health(w, r, false)
 	}).Methods(http.MethodOptions, http.MethodGet)
 	router.HandleFunc("/kurbisio/health/purge", func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		if b.authorizationEnabled {
 			auth := access.AuthorizationFromContext(r.Context())
 			if !auth.HasRole("admin") {
@@ -204,7 +204,7 @@ WHERE serial = $1 RETURNING serial;`
 		b.purgeHealth(w, r)
 	}).Methods(http.MethodOptions, http.MethodPut)
 	router.HandleFunc("/kurbisio/health/details", func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		if b.authorizationEnabled {
 			auth := access.AuthorizationFromContext(r.Context())
 			if !auth.HasRole("admin") && !auth.HasRole("admin viewer") {

--- a/core/backend/jobs.go
+++ b/core/backend/jobs.go
@@ -390,7 +390,6 @@ func (b *Backend) eventsWithAuth(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	eventType := params["event"]
 	rlog := logger.FromContext(r.Context())
-	rlog.Infoln("in events with auth")
 	if b.authorizationEnabled {
 		auth := access.AuthorizationFromContext(r.Context())
 		if !auth.HasRole("admin") {
@@ -551,12 +550,12 @@ func (b *Backend) pipelineWorker(n int, jobs <-chan job, ready chan<- bool, time
 		tickerDone <- true
 
 		if err == rescheduledError {
-			rlog.Info("successfully rescheduled rate limited event " + key + "[" + jb.Key + "] #" + strconv.Itoa(jb.Serial))
+			rlog.Debug("successfully rescheduled rate limited event " + key + "[" + jb.Key + "] #" + strconv.Itoa(jb.Serial))
 
 		} else if err != nil {
 			rlog.WithError(err).Error("error processing " + key + "[" + jb.Key + "] #" + strconv.Itoa(jb.Serial))
 		} else {
-			rlog.Info("successfully processed " + key + "[" + jb.Key + "] #" + strconv.Itoa(jb.Serial))
+			rlog.Debug("successfully processed " + key + "[" + jb.Key + "] #" + strconv.Itoa(jb.Serial))
 			// job handled sucessfully, delete from queue (unless it has been rescheduled and attempts_left is back at 5)
 			var serial int
 			err = b.db.QueryRow(b.jobsDeleteQuery[jb.Priority], &jb.Serial).Scan(&serial)

--- a/core/backend/relation.go
+++ b/core/backend/relation.go
@@ -206,7 +206,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc relationConfigur
 
 	// LIST LEFT
 	router.HandleFunc(leftListRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 
 		params := mux.Vars(r)
 		if b.authorizationEnabled {
@@ -296,7 +296,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc relationConfigur
 
 	// LIST RIGHT
 	router.HandleFunc(rightListRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 
 		params := mux.Vars(r)
 		if b.authorizationEnabled {
@@ -386,7 +386,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc relationConfigur
 
 	// READ LEFT
 	router.HandleFunc(leftItemRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		params := mux.Vars(r)
 		if b.authorizationEnabled {
 			auth := access.AuthorizationFromContext(r.Context())
@@ -411,7 +411,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc relationConfigur
 
 	// READ RIGHT
 	router.HandleFunc(rightItemRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		params := mux.Vars(r)
 		if b.authorizationEnabled {
 			auth := access.AuthorizationFromContext(r.Context())
@@ -474,7 +474,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc relationConfigur
 
 	// CREATE LEFT
 	router.HandleFunc(leftItemRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 
 		params := mux.Vars(r)
 		if b.authorizationEnabled {
@@ -493,7 +493,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc relationConfigur
 
 	// CREATE RIGHT
 	router.HandleFunc(rightItemRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 
 		params := mux.Vars(r)
 		if b.authorizationEnabled {
@@ -537,7 +537,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc relationConfigur
 
 	// DELETE LEFT
 	router.HandleFunc(leftItemRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 
 		params := mux.Vars(r)
 		if b.authorizationEnabled {
@@ -552,7 +552,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc relationConfigur
 
 	// DELETE RIGHT
 	router.HandleFunc(rightItemRoute, func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 
 		params := mux.Vars(r)
 		if b.authorizationEnabled {

--- a/core/backend/statistics.go
+++ b/core/backend/statistics.go
@@ -40,7 +40,7 @@ func (b *Backend) handleStatistics(router *mux.Router) {
 	logger.Default().Debugln("statistics")
 	logger.Default().Debugln("  handle statistics route: /kuribisio/statistics GET")
 	router.Handle("/kurbisio/statistics", handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).Infoln("called route for", r.URL, r.Method)
+		logger.FromContext(r.Context()).Debugln("called route for", r.URL, r.Method)
 		b.statisticsWithAuth(w, r)
 	}))).Methods(http.MethodOptions, http.MethodGet)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/relabs-tech/kurbisio
 
-go 1.17
+go 1.21
 
 require (
 	github.com/DrmagicE/gmqtt v0.1.2


### PR DESCRIPTION
when jobs run longer than the retry timeout, we must renew the retry to avoid triggering a retry before the job has actually finished