### PR TITLE
introduce new relation resources

### DIFF
--- a/core/backend/backend_test.go
+++ b/core/backend/backend_test.go
@@ -170,13 +170,6 @@ var configurationJSON string = `{
 	  }
 
 	],
-	"relations": [
-		{
-			"resource":"named_relation",
-			"left":"a",
-			"right":"b"
-		}
-	],
 	"shortcuts": [
 		{
 			"shortcut" : "b",

--- a/core/backend/config_schema.json
+++ b/core/backend/config_schema.json
@@ -205,6 +205,90 @@
                 "type": "object",
                 "additionalProperties": false,
                 "required": [
+                    "resource",
+                    "left",
+                    "right"
+                ],
+                "properties": {
+                    "default": {
+                        "type": "object"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "non_directional": {
+                        "type": "boolean",
+                        "description": "If true this relation is non-directional, left and right will be sorted lexicographically. This is only posisble of left and right are the same resource type"
+                    },
+                    "external_index": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "resource": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "audit_logs": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "create",
+                                "read",
+                                "update",
+                                "delete",
+                                "clear"
+                            ]
+                        },
+                        "description": "List of audit log resources to be used for this collection"
+                    },
+                    "permits": {
+                        "$ref": "#/definitions/permits"
+                    },
+                    "schema_id": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "left": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "right": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "searchable_properties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "minLength": 1
+                        }
+                    },
+                    "static_properties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "minLength": 1
+                        }
+                    },
+                    "with_companion_file": {
+                        "type": "boolean",
+                        "description": "If true this resource will allow to add companion file stored externally"
+                    },
+                    "companion_presigned_url_validity": {
+                        "type": "integer",
+                        "minimum": 60,
+                        "description": "The validity in seconds of the pre signed URL. Defaults to 900 (15 minutes)"
+                    }
+                }
+            }
+        },
+        "relations_old": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
                     "left",
                     "right"
                 ],

--- a/core/backend/configuration.go
+++ b/core/backend/configuration.go
@@ -104,12 +104,21 @@ type BlobConfiguration struct {
 // RelationConfiguration is a n:m relation from
 // another collection, blob collection or relation
 type RelationConfiguration struct {
-	Resource     string          `json:"resource"`
-	Left         string          `json:"left"`
-	Right        string          `json:"right"`
-	LeftPermits  []access.Permit `json:"left_permits"`
-	RightPermits []access.Permit `json:"right_permits"`
-	Description  string          `json:"description"`
+	Resource                      string          `json:"resource"`
+	ExternalIndex                 string          `json:"external_index"`
+	StaticProperties              []string        `json:"static_properties"`
+	SearchableProperties          []string        `json:"searchable_properties"`
+	Permits                       []access.Permit `json:"permits"`
+	Description                   string          `json:"description"`
+	SchemaID                      string          `json:"schema_id"`
+	Default                       json.RawMessage `json:"default"`
+	WithCompanionFile             bool            `json:"with_companion_file"`
+	CompanionPresignedURLValidity int             `json:"companion_presigned_url_validity"`
+	needsKSS                      bool            // true of this collection or any subcollection or subblob needs kss
+	AuditLogs                     []AuditLog      `json:"audit_logs"`      // list of audit log names to use for this collection
+	NonDirectional                bool            `json:"non_directional"` // if true this relation is non-directional, left and right will be sorted lexicographically. This is only possible if left and right are the same resource type
+	Left                          string          `json:"left"`
+	Right                         string          `json:"right"`
 }
 
 // ShortcutConfiguration is shortcut to a resource

--- a/core/backend/cursor.go
+++ b/core/backend/cursor.go
@@ -22,6 +22,53 @@ type PaginationCursor struct {
 	ID        uuid.UUID `json:"id"`
 }
 
+// PaginationDoubleCursor represents a cursor for pagination containing timestamp and two IDs
+type PaginationDoubleCursor struct {
+	Timestamp time.Time `json:"timestamp"`
+	LeftID    uuid.UUID `json:"left_id"`
+	RightID   uuid.UUID `json:"right_id"`
+}
+
+// Encode encodes the double cursor to a base64 string format
+func (c PaginationDoubleCursor) Encode() string {
+	encoded := fmt.Sprintf("%d.%s.%s", c.Timestamp.UnixNano(), c.LeftID.String(), c.RightID.String())
+	return base64.URLEncoding.EncodeToString([]byte(encoded))
+}
+
+// DecodePaginationDoubleCursor decodes a base64 cursor string back to PaginationDoubleCursor
+func DecodePaginationDoubleCursor(encoded string) (PaginationDoubleCursor, error) {
+	decoded, err := base64.URLEncoding.DecodeString(encoded)
+	if err != nil {
+		return PaginationDoubleCursor{}, fmt.Errorf("invalid double cursor format: %v", err)
+	}
+
+	parts := strings.SplitN(string(decoded), ".", 3)
+	if len(parts) != 3 {
+		return PaginationDoubleCursor{}, fmt.Errorf("invalid double cursor format: %s", encoded)
+	}
+
+	timestampNano, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return PaginationDoubleCursor{}, fmt.Errorf("invalid timestamp in double cursor: %v", err)
+	}
+
+	leftID, err := uuid.Parse(parts[1])
+	if err != nil {
+		return PaginationDoubleCursor{}, fmt.Errorf("invalid LeftID in double cursor: %v", err)
+	}
+
+	rightID, err := uuid.Parse(parts[2])
+	if err != nil {
+		return PaginationDoubleCursor{}, fmt.Errorf("invalid RightID in double cursor: %v", err)
+	}
+
+	return PaginationDoubleCursor{
+		Timestamp: time.Unix(0, timestampNano).UTC(),
+		LeftID:    leftID,
+		RightID:   rightID,
+	}, nil
+}
+
 // Encode encodes the cursor to a base64 string format
 func (c PaginationCursor) Encode() string {
 	encoded := fmt.Sprintf("%d.%s", c.Timestamp.UnixNano(), c.ID.String())

--- a/core/backend/interceptors.go
+++ b/core/backend/interceptors.go
@@ -20,7 +20,7 @@ type Request struct {
 	// Resource for which this request is made
 	Resource string
 	// the primary ID for the resource, for singletons this is the parent ID, for
-	// list requests this is a  null uuid.
+	// list requests or relations requests this is a  null uuid.
 	ResourceID uuid.UUID
 	// Operation for this request
 	Operation core.Operation

--- a/core/backend/relation_test.go
+++ b/core/backend/relation_test.go
@@ -22,81 +22,52 @@ import (
 	"github.com/relabs-tech/kurbisio/core/csql"
 )
 
-func TestRelation(t *testing.T) {
-	// Create a relation and verifies that the relation can be listed
+func TestRelationDirectional(t *testing.T) {
 
 	if err := envdecode.Decode(&testService); err != nil {
 		panic(err)
 	}
 
-	db := csql.OpenWithSchema(testService.Postgres, testService.PostgresPassword, "_backend_relation_unit_test_")
+	db := csql.OpenWithSchema(testService.Postgres, testService.PostgresPassword, "_backend_relation_directional_unit_test_")
 	defer db.Close()
 	db.ClearSchema()
 
 	var configurationJSON string = `{
 		"collections": [			
-
 	    	{
-			"resource": "a",
-			"permits": [
-				{
-					"role": "role1",
-					"operations": [
-						"create",
-						"update"
-					]
-				}
-			]	
-		  },
-		  {
-			"resource": "b",
-			"permits": [
-				{
-					"role": "role1",
-					"operations": [
-						"create",
-						"update"
-					]
-				},
-				{
-					"role": "role2",
-					"operations": [
-						"read"
-					]
-				}
-			]
-		  }
+				"resource": "a"
+		  	},
+		  	{
+				"resource": "b"
+		  	}
 		],
 		"relations": [
 			{
+				"resource": "a_b_relation",
 				"left": "a",
 				"right": "b",
-				"left_permits": [
+				"permits": [
 					{
-						"role": "role2",
+						"role": "role1",
 						"operations": [
 							"read",
-							"create",							
+							"create",
+							"update",							
 							"list",
 							"delete"
 						]
-					}
-				],
-				"right_permits": [
+					},
 					{
 						"role": "role2",
 						"operations": [
-							"read",				
-							"list"
-						]
-					},
-					{
-						"role": "role1",
-						"operations": [										
-							"list"
+							"read",										
+							"list",
+							"delete"
+						],
+						"selectors": [
+							"a"
 						]
 					}
-
 				]
 			}
 		]
@@ -109,8 +80,10 @@ func TestRelation(t *testing.T) {
 		Router:               router,
 		UpdateSchema:         true,
 		AuthorizationEnabled: true,
+		LogLevel:             "debug",
 	})
-	role1Client := client.NewWithRouter(router).WithRole("role1")
+
+	adminClient := client.NewWithRouter(router).WithAdminAuthorization()
 
 	type A struct {
 		AID       uuid.UUID `json:"a_id"`
@@ -121,178 +94,284 @@ func TestRelation(t *testing.T) {
 		Timestamp time.Time `json:"timestamp,omitempty"`
 	}
 
-	// First we create an A and a B
+	type MyRelation struct {
+		AID       uuid.UUID `json:"a_id"`
+		BID       uuid.UUID `json:"b_id"`
+		Timestamp time.Time `json:"timestamp,omitempty"`
+		Index     int       `json:"index,omitempty"`
+	}
+
+	// First we create an two As and a B
 	a := A{AID: uuid.New()}
-	_, err := role1Client.RawPut("/as", &a, &a)
+	_, err := adminClient.RawPut("/as", &a, &a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a2 := A{AID: uuid.New()}
+	_, err = adminClient.RawPut("/as", &a2, &a2)
 	if err != nil {
 		t.Fatal(err)
 	}
 	b := B{BID: uuid.New()}
-	_, err = role1Client.RawPut("/bs", &b, nil)
+	_, err = adminClient.RawPut("/bs", &b, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	role2Client := client.NewWithRouter(router).WithRole("role2")
+	role1Client := client.NewWithRouter(router).WithRole("role1")
+	role2Client := client.NewWithRouter(router).WithRoleAndSelector("role2", "a", a.AID)
 
-	// Check that role2 does not allow to create a relation b/a (role2 lacks create on right permits)
-	status, _ := role2Client.RawPut(fmt.Sprintf("/bs/%s/as/%s", b.BID, a.AID), nil, nil)
+	// Check that role2 does not allow to create a relation b/a (role2 lacks create on permits)
+	status, _ := role2Client.RawPut(fmt.Sprintf("/a_b_relations/%v:%v", a.AID, b.BID), nil, nil)
 	if status != http.StatusUnauthorized {
 		t.Fatalf("Expecting unauthorized access, got %v", status)
 	}
 
 	// Then we create the relation a/b
-	_, err = role2Client.RawPut(fmt.Sprintf("/as/%s/bs/%s", a.AID, b.BID), nil, nil)
+	_, err = role1Client.RawPut(fmt.Sprintf("/a_b_relations/%v:%v", a.AID, b.BID), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// We verify that role1 cannot list the relation a/b, but only b/a
-	status, _ = role1Client.RawGet(fmt.Sprintf("/as/%s/bs", a.AID), &[]B{})
+	// Then we create the relation a2/b
+	_, err = role1Client.RawPut(fmt.Sprintf("/a_b_relations/%v:%v", a2.AID, b.BID), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We verify that role2 cannot list relations ?/b
+	a_b_relations := []MyRelation{}
+	status, _ = role2Client.RawGet(fmt.Sprintf("/a_b_relations?right=%v", b.BID), &a_b_relations)
 	if status != http.StatusUnauthorized {
 		t.Fatalf("Expecting unauthorized access, got %v", status)
 	}
-	status, _ = role1Client.RawGet(fmt.Sprintf("/bs/%s/as", b.BID), &[]B{})
+
+	// We verify that role1 can list all relations ?/b
+	status, _ = role1Client.RawGet(fmt.Sprintf("/a_b_relations?right=%v", b.BID), &a_b_relations)
 	if status != http.StatusOK {
-		t.Fatalf("Expecting unauthorized access, got %v", status)
+		t.Fatalf("Expecting access, got %v", status)
+	}
+	if len(a_b_relations) != 2 {
+		t.Fatalf("Expecting two relations, got %d", len(a_b_relations))
 	}
 
-	// We verify that role2 can list the relation in both directions
-	bs := []B{}
-	_, err = role2Client.RawGet(fmt.Sprintf("/as/%s/bs", a.AID), &bs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(bs) != 1 {
-		t.Fatalf("Expecting one relation, got %d", len(bs))
-	}
-	if bs[0].BID != b.BID {
-		t.Fatalf("Expecting %s, got %s", b.BID, bs[0].BID)
-	}
-
-	as := []A{}
-	_, err = role2Client.RawGet(fmt.Sprintf("/bs/%s/as", b.BID), &as)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(as) != 1 {
-		t.Fatalf("Expecting one relation, got %d", len(as))
-	}
-	if as[0].AID != a.AID {
-		t.Fatalf("Expecting %s, got %s", a.AID, as[0].AID)
-	}
-
-	// Check that role2 does not allow to list nor read as
-	status, _ = role2Client.RawGet(fmt.Sprintf("/as/%s", b.BID), nil)
-	if status != http.StatusUnauthorized {
-		t.Fatalf("Expecting unauthorized access, got %v", status)
-	}
-	status, _ = role2Client.RawGet("/bs", nil)
-	if status != http.StatusUnauthorized {
-		t.Fatalf("Expecting unauthorized access, got %v", status)
-	}
-	status, _ = role2Client.RawGet("/as", nil)
+	// We verify that role2 cannot get the relations a2/b, but only a/b
+	var a_b_relation MyRelation
+	status, _ = role2Client.RawGet(fmt.Sprintf("/a_b_relations/%v:%v", a2.AID, b.BID), &a_b_relation)
 	if status != http.StatusUnauthorized {
 		t.Fatalf("Expecting unauthorized access, got %v", status)
 	}
 
-	// Check that role2 does not allow to delete b/a
-	status, _ = role2Client.RawDelete(fmt.Sprintf("/bs/%s/as/%s", b.BID, a.AID))
+	status, _ = role2Client.RawGet(fmt.Sprintf("/a_b_relations/%v:%v", a.AID, b.BID), &a_b_relation)
+	if status != http.StatusOK {
+		t.Fatalf("Expecting access, got %v", status)
+	}
+	if a_b_relation.AID != a.AID {
+		t.Fatalf("Expecting AID=%v, got %v", a.AID, a_b_relation.AID)
+	}
+	if a_b_relation.BID != b.BID {
+		t.Fatalf("Expecting BID=%v, got %v", b.BID, a_b_relation.BID)
+	}
+
+	// We verify that role2 cannot list the relation a2/?, but only a/?
+	a_b_relations = []MyRelation{}
+	status, _ = role2Client.RawGet(fmt.Sprintf("/a_b_relations?left=%v", a2.AID), &a_b_relations)
+	if status != http.StatusUnauthorized {
+		t.Fatalf("Expecting unauthorized access, got %v", status)
+	}
+	a_b_relations = []MyRelation{}
+	status, _ = role2Client.RawGet(fmt.Sprintf("/a_b_relations?left=%v", a.AID), &a_b_relations)
+	if status != http.StatusOK {
+		t.Fatalf("Expecting access, got %v", status)
+	}
+
+	if len(a_b_relations) != 1 {
+		t.Fatalf("Expecting one relation, got %d", len(a_b_relations))
+	}
+	if a_b_relations[0].AID != a.AID {
+		t.Fatalf("Expecting AID=%v, got %v", a.AID, a_b_relations[0].AID)
+	}
+	if a_b_relations[0].BID != b.BID {
+		t.Fatalf("Expecting BID=%v, got %v", b.BID, a_b_relations[0].BID)
+	}
+
+	// We verify that role1 can list the relation in both directions
+	status, _ = role1Client.RawGet(fmt.Sprintf("/a_b_relations?left=%v", a2.AID), nil)
+	if status != http.StatusOK {
+		t.Fatalf("Expecting access, got %v", status)
+	}
+	status, _ = role1Client.RawGet(fmt.Sprintf("/a_b_relations?left=%v", a.AID), nil)
+	if status != http.StatusOK {
+		t.Fatalf("Expecting access, got %v", status)
+	}
+
+	// We verify that role2 can read relation a/b but not a2/b
+	myrelation := MyRelation{}
+	status, _ = role2Client.RawGet(fmt.Sprintf("/a_b_relations/%v:%v", a.AID, b.BID), &myrelation)
+	if status != http.StatusOK {
+		t.Fatalf("Expecting access, got %v", status)
+	}
+	if myrelation.AID != a.AID {
+		t.Fatalf("Expecting AID=%v, got %v", a.AID, myrelation.AID)
+	}
+	if myrelation.BID != b.BID {
+		t.Fatalf("Expecting BID=%v, got %v", b.BID, myrelation.BID)
+	}
+
+	status, _ = role2Client.RawGet(fmt.Sprintf("/a_b_relations/%v:%v", a2.AID, b.BID), nil)
 	if status != http.StatusUnauthorized {
 		t.Fatalf("Expecting unauthorized access, got %v", status)
 	}
 
-	// Check that role2 allows to delete a/b
-	_, err = role2Client.RawDelete(fmt.Sprintf("/as/%s/bs/%s", a.AID, b.BID))
-	if err != nil {
-		t.Fatal(err)
+	// We verify that role1 can read relation a/b and a2/b
+	status, _ = role1Client.RawGet(fmt.Sprintf("/a_b_relations/%v:%v", a.AID, b.BID), &myrelation)
+	if status != http.StatusOK {
+		t.Fatalf("Expecting access, got %v", status)
 	}
-	_, err = role2Client.RawGet(fmt.Sprintf("/bs/%s/as", b.BID), &as)
-	if err != nil {
-		t.Fatal(err)
+	if myrelation.AID != a.AID {
+		t.Fatalf("Expecting AID=%v, got %v", a.AID, myrelation.AID)
 	}
-	if len(as) != 0 {
-		t.Fatalf("Expecting 0 relation, got %d", len(as))
+	if myrelation.BID != b.BID {
+		t.Fatalf("Expecting BID=%v, got %v", b.BID, myrelation.BID)
 	}
+	status, _ = role1Client.RawGet(fmt.Sprintf("/a_b_relations/%v:%v", a2.AID, b.BID), &myrelation)
+	if status != http.StatusOK {
+		t.Fatalf("Expecting access, got %v", status)
+	}
+	if myrelation.AID != a2.AID {
+		t.Fatalf("Expecting AID=%v, got %v", a2.AID, myrelation.AID)
+	}
+	if myrelation.BID != b.BID {
+		t.Fatalf("Expecting BID=%v, got %v", b.BID, myrelation.BID)
+	}
+
+	// We verify that role1 can delete the relation a/b
+	status, _ = role1Client.RawDelete(fmt.Sprintf("/a_b_relations/%v:%v", a.AID, b.BID))
+	if status != http.StatusNoContent {
+		t.Fatalf("Expecting no content, got %v", status)
+	}
+
+	// We verify that relation a/b is gone
+	status, _ = role1Client.RawGet(fmt.Sprintf("/a_b_relations/%v:%v", a.AID, b.BID), nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("Expecting not found, got %v", status)
+	}
+
+	// We verify that relation a2/b is still there
+	status, _ = role1Client.RawGet(fmt.Sprintf("/a_b_relations/%v:%v", a2.AID, b.BID), &myrelation)
+	if status != http.StatusOK {
+		t.Fatalf("Expecting access, got %v", status)
+	}
+
+	// Create 1000 b objects
+	startTime := time.Now().Add(-time.Minute * 1000).UTC()
+	for i := 0; i < 1000; i++ {
+		var b B
+		status, err = adminClient.RawPost("/bs", b, &b)
+		if status != http.StatusCreated {
+			t.Fatalf("Expecting created, got %v (%v)", status, err)
+		}
+		// and create a relation a2/b for each
+		relation := MyRelation{
+			AID:       a.AID,
+			BID:       b.BID,
+			Timestamp: startTime.Add(time.Duration(i) * time.Minute).UTC(),
+			Index:     i,
+		}
+		status, err = role1Client.RawPut("/a_b_relations", &relation, nil)
+		if status != http.StatusCreated {
+			t.Fatalf("Expecting created, got %v (%v)", status, err)
+		}
+	}
+
+	// Verify that we can list all relations a2/? in the right order with cursor pagination, defaulting to a limit of 100 items per page
+	var allRelations []MyRelation
+
+	for page := role1Client.Collection("a_b_relation").WithParameter("order", "asc").WithLeft(a.AID).FirstPage(); page.HasData(); page = page.Next() {
+		var onePage []MyRelation
+		_, err := page.Get(&onePage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(onePage) != 100 {
+			t.Fatalf("Expecting 100 items, got %d", len(onePage))
+		}
+		allRelations = append(allRelations, onePage...)
+	}
+
+	if len(allRelations) != 1000 {
+		t.Fatalf("Expecting 1000 relations, got %d", len(allRelations))
+	}
+	for i, relation := range allRelations {
+		if relation.AID != a.AID {
+			t.Fatalf("Expecting AID=%v, got %v at index %d", a.AID, relation.AID, i)
+		}
+		if relation.BID == uuid.Nil {
+			t.Fatalf("Expecting valid BID, got nil at index %d", i)
+		}
+		if relation.Index != i {
+			t.Fatalf("Expecting Index=%d, got %d at index %d", i, relation.Index, i)
+		}
+		expectedTimestamp := startTime.Add(time.Duration(i) * time.Minute).UTC()
+		if !relation.Timestamp.Equal(expectedTimestamp) {
+			t.Fatalf("Expecting Timestamp=%v, got %v at index %d", expectedTimestamp, relation.Timestamp, i)
+		}
+	}
+
+	// Verify that deleting a specific b deletes all relations to b
+	status, _ = adminClient.RawDelete(fmt.Sprintf("/bs/%v", allRelations[0].BID))
+	if status != http.StatusNoContent {
+		t.Fatalf("Expecting no content, got %v", status)
+	}
+	// Verify that all relations to b are gone
+	relations := []MyRelation{}
+	status, _ = role1Client.RawGet(fmt.Sprintf("/a_b_relations?right=%v", allRelations[0].BID), &relations)
+	if status != http.StatusOK {
+		t.Fatalf("Expecting access, got %v", status)
+	}
+	if len(relations) != 0 {
+		t.Fatalf("Expecting no relations, got %d", len(relations))
+	}
+
+	// Verify that deleting a does delete all relations from a
+	status, _ = adminClient.RawDelete(fmt.Sprintf("/as/%v", a.AID))
+	if status != http.StatusNoContent {
+		t.Fatalf("Expecting no content, got %v", status)
+	}
+	// Verify that all relations from a are gone
+	relations = []MyRelation{}
+	status, _ = role1Client.RawGet(fmt.Sprintf("/a_b_relations?left=%v", a.AID), &relations)
+	if status != http.StatusOK {
+		t.Fatalf("Expecting access, got %v", status)
+	}
+	if len(relations) != 0 {
+		t.Fatalf("Expecting no relations, got %d", len(relations))
+	}
+
 }
 
-func TestRelationNamed(t *testing.T) {
-	// Create a relation and verifies that the relation can be listed
+func TestRelationNonDirectional(t *testing.T) {
 
 	if err := envdecode.Decode(&testService); err != nil {
 		panic(err)
 	}
 
-	db := csql.OpenWithSchema(testService.Postgres, testService.PostgresPassword, "_backend_relation_unit_test_")
+	db := csql.OpenWithSchema(testService.Postgres, testService.PostgresPassword, "_backend_relation_non_directional_unit_test_")
 	defer db.Close()
 	db.ClearSchema()
 
 	var configurationJSON string = `{
 		"collections": [			
-
 	    	{
-			"resource": "a",
-			"permits": [
-				{
-					"role": "role1",
-					"operations": [
-						"create",
-						"update"
-					]
-				}
-			]	
-		  },
-		  {
-			"resource": "b",
-			"permits": [
-				{
-					"role": "role1",
-					"operations": [
-						"create",
-						"update"
-					]
-				},
-				{
-					"role": "role2",
-					"operations": [
-						"read"
-					]
-				}
-			]
-		  }
+				"resource": "a"
+		  	}
 		],
 		"relations": [
 			{
-				"resource": "myrelation",
+				"resource": "a_a_relation",
 				"left": "a",
-				"right": "b",
-				"left_permits": [
-					{
-						"role": "role2",
-						"operations": [
-							"read",
-							"create",							
-							"list",
-							"delete"
-						]
-					}
-				],
-				"right_permits": [
-					{
-						"role": "role2",
-						"operations": [
-							"read",				
-							"list"
-						]
-					},
-					{
-						"role": "role1",
-						"operations": [										
-							"list"
-						]
-					}
-
-				]
+				"right": "a",
+				"non_directional": true
 			}
 		]
 	  }
@@ -304,110 +383,176 @@ func TestRelationNamed(t *testing.T) {
 		Router:               router,
 		UpdateSchema:         true,
 		AuthorizationEnabled: true,
+		LogLevel:             "debug",
 	})
-	role1Client := client.NewWithRouter(router).WithRole("role1")
+
+	adminClient := client.NewWithRouter(router).WithAdminAuthorization()
 
 	type A struct {
-		AID       uuid.UUID `json:"a_id"`
-		Timestamp time.Time `json:"timestamp,omitempty"`
-	}
-	type B struct {
-		BID       uuid.UUID `json:"b_id"`
-		Timestamp time.Time `json:"timestamp,omitempty"`
+		AID uuid.UUID `json:"a_id"`
 	}
 
-	// First we create an A and a B
+	type MyRelation struct {
+		LeftAID  uuid.UUID `json:"left_a_id"`
+		RightAID uuid.UUID `json:"right_a_id"`
+		Text     string    `json:"text,omitempty"`
+	}
+
+	// First we create an a
 	a := A{AID: uuid.New()}
-	_, err := role1Client.RawPut("/as", &a, &a)
-	if err != nil {
-		t.Fatal(err)
-	}
-	b := B{BID: uuid.New()}
-	_, err = role1Client.RawPut("/bs", &b, nil)
+	_, err := adminClient.RawPut("/as", &a, &a)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	role2Client := client.NewWithRouter(router).WithRole("role2")
-
-	// Check that role2 does not allow to create a relation b/a (role2 lacks create on right permits)
-	status, _ := role2Client.RawPut(fmt.Sprintf("/myrelation/bs/%s/as/%s", b.BID, a.AID), nil, nil)
-	if status != http.StatusUnauthorized {
-		t.Fatalf("Expecting unauthorized access, got %v", status)
+	// Then we create 10 new as, and a relation between a and each of them
+	for i := 0; i < 10; i++ {
+		var a2 A
+		status, err := adminClient.RawPost("/as", a2, &a2)
+		if status != http.StatusCreated {
+			t.Fatalf("Expecting created, got %v (%v)", status, err)
+		}
+		// and create a relation a/a2 for each
+		relation := MyRelation{
+			LeftAID:  a.AID,
+			RightAID: a2.AID,
+		}
+		status, err = adminClient.RawPut("/a_a_relations", &relation, nil)
+		if status != http.StatusCreated {
+			t.Fatalf("Expecting created, got %v (%v)", status, err)
+		}
 	}
 
-	// Then we create the relation a/b
-	_, err = role2Client.RawPut(fmt.Sprintf("/myrelation/as/%s/bs/%s", a.AID, b.BID), nil, nil)
+	// Then we again create 10 new as, and a relation between each of them and a
+	for i := 0; i < 10; i++ {
+		var a2 A
+		status, err := adminClient.RawPost("/as", a2, &a2)
+		if status != http.StatusCreated {
+			t.Fatalf("Expecting created, got %v (%v)", status, err)
+		}
+		// and create a relation a/a2 for each
+		relation := MyRelation{
+			LeftAID:  a2.AID,
+			RightAID: a.AID,
+		}
+		status, err = adminClient.RawPut("/a_a_relations", &relation, nil)
+		if status != http.StatusCreated {
+			t.Fatalf("Expecting created, got %v (%v)", status, err)
+		}
+	}
+
+	var relations []MyRelation
+	_, err = adminClient.RawGet("/a_a_relations?either="+a.AID.String(), &relations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(relations) != 20 {
+		t.Fatalf("Expecting 20 relations, got %d", len(relations))
+	}
+
+	var leftRelations []MyRelation
+	_, err = adminClient.RawGet("/a_a_relations?filter=left_a_id="+a.AID.String(), &leftRelations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rightRelations []MyRelation
+	_, err = adminClient.RawGet("/a_a_relations?filter=right_a_id="+a.AID.String(), &rightRelations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftRelations)+len(rightRelations) != 20 {
+		t.Fatalf("Expecting 20 relations, got %d+%d", len(leftRelations), len(rightRelations))
+	}
+
+	someAID := relations[3].LeftAID
+	if someAID == a.AID {
+		someAID = relations[3].RightAID
+	}
+
+	// Verify that someAID is different from a.AID
+	if someAID == a.AID {
+		t.Fatalf("someAID should not be equal to a.AID, got the same")
+	}
+
+	// We verify that someAID has one relation
+	relations = []MyRelation{}
+	_, err = adminClient.RawGet("/a_a_relations?either="+someAID.String(), &relations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(relations) != 1 {
+		t.Fatalf("Expecting 1 relation, got %d", len(relations))
+	}
+
+	// We verify that we can clear relations with a filter
+	_, err = adminClient.RawDelete("/a_a_relations?either=" + someAID.String())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// We verify that role1 cannot list the relation a/b, but only b/a
-	status, _ = role1Client.RawGet(fmt.Sprintf("/myrelation/as/%s/bs", a.AID), &[]B{})
-	if status != http.StatusUnauthorized {
-		t.Fatalf("Expecting unauthorized access, got %v", status)
-	}
-	status, _ = role1Client.RawGet(fmt.Sprintf("/myrelation/bs/%s/as", b.BID), &[]B{})
-	if status != http.StatusOK {
-		t.Fatalf("Expecting unauthorized access, got %v", status)
-	}
-
-	// We verify that role2 can list the relation in both directions
-	bs := []B{}
-	_, err = role2Client.RawGet(fmt.Sprintf("/myrelation/as/%s/bs", a.AID), &bs)
+	// We verify that all relations with the given a are gone
+	relations = []MyRelation{}
+	_, err = adminClient.RawGet("/a_a_relations?either="+someAID.String(), &relations)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(bs) != 1 {
-		t.Fatalf("Expecting one relation, got %d", len(bs))
-	}
-	if bs[0].BID != b.BID {
-		t.Fatalf("Expecting %s, got %s", b.BID, bs[0].BID)
+	if len(relations) != 0 {
+		t.Fatalf("Expecting no relations, got %d", len(relations))
 	}
 
-	as := []A{}
-	_, err = role2Client.RawGet(fmt.Sprintf("/myrelation/bs/%s/as", b.BID), &as)
+	// We verify that we now have 1 relation less
+	relations = []MyRelation{}
+	_, err = adminClient.RawGet("/a_a_relations?either="+a.AID.String(), &relations)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(as) != 1 {
-		t.Fatalf("Expecting one relation, got %d", len(as))
-	}
-	if as[0].AID != a.AID {
-		t.Fatalf("Expecting %s, got %s", a.AID, as[0].AID)
+	if len(relations) != 19 {
+		t.Fatalf("Expecting 19 relations, got %d", len(relations))
 	}
 
-	// Check that role2 does not allow to list nor read as
-	status, _ = role2Client.RawGet(fmt.Sprintf("/as/%s", b.BID), nil)
-	if status != http.StatusUnauthorized {
-		t.Fatalf("Expecting unauthorized access, got %v", status)
+	// One more test that non-directional relations are indeed non-directional
+
+	// verify that a and someAID have no relation
+	relation := MyRelation{}
+	status, _ := adminClient.RawGet(fmt.Sprintf("/a_a_relations/%v:%v", a.AID, someAID), &relation)
+	if status != http.StatusNotFound {
+		t.Fatalf("Expecting not found, got %v", status)
 	}
-	status, _ = role2Client.RawGet("/bs", nil)
-	if status != http.StatusUnauthorized {
-		t.Fatalf("Expecting unauthorized access, got %v", status)
-	}
-	status, _ = role2Client.RawGet("/as", nil)
-	if status != http.StatusUnauthorized {
-		t.Fatalf("Expecting unauthorized access, got %v", status)
+	// verify that someAID and a have no relation
+	relation = MyRelation{}
+	status, _ = adminClient.RawGet(fmt.Sprintf("/a_a_relations/%v:%v", someAID, a.AID), &relation)
+	if status != http.StatusNotFound {
+		t.Fatalf("Expecting not found, got %v", status)
 	}
 
-	// Check that role2 does not allow to delete b/a
-	status, _ = role2Client.RawDelete(fmt.Sprintf("/myrelation/bs/%s/as/%s", b.BID, a.AID))
-	if status != http.StatusUnauthorized {
-		t.Fatalf("Expecting unauthorized access, got %v", status)
-	}
-
-	// Check that role2 allows to delete a/b
-	_, err = role2Client.RawDelete(fmt.Sprintf("/myrelation/as/%s/bs/%s", a.AID, b.BID))
+	// create a new relation between a and someAID
+	_, err = adminClient.RawPut("/a_a_relations", &MyRelation{
+		LeftAID:  a.AID,
+		RightAID: someAID,
+		Text:     "magic token",
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = role2Client.RawGet(fmt.Sprintf("/myrelation/bs/%s/as", b.BID), &as)
+
+	// read it back with left and right as they are
+	relation = MyRelation{}
+	_, err = adminClient.RawGet(fmt.Sprintf("/a_a_relations/%v:%v", a.AID, someAID), &relation)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(as) != 0 {
-		t.Fatalf("Expecting 0 relation, got %d", len(as))
+	if relation.Text != "magic token" {
+		t.Fatalf("Expecting magic token, got %s", relation.Text)
+	}
+
+	// read it back with left and right swapped
+	relation = MyRelation{}
+	_, err = adminClient.RawGet(fmt.Sprintf("/a_a_relations/%v:%v", someAID, a.AID), &relation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if relation.Text != "magic token" {
+		t.Fatalf("Expecting magic token, got %s", relation.Text)
 	}
 }
 

--- a/core/backend/statistics.go
+++ b/core/backend/statistics.go
@@ -64,11 +64,7 @@ func (b *Backend) statisticsWithAuth(w http.ResponseWriter, r *http.Request) {
 		singletons = append(singletons, r.Resource)
 	}
 	for _, r := range b.config.Relations {
-		resource := r.Left + ":" + r.Right
-		if r.Resource != "" {
-			resource = r.Resource + ":" + resource
-		}
-		relations = append(relations, resource)
+		relations = append(relations, r.Resource)
 	}
 	for _, r := range b.config.Blobs {
 		blobs = append(blobs, r.Resource)

--- a/core/backend/statistics_test.go
+++ b/core/backend/statistics_test.go
@@ -54,12 +54,7 @@ func TestStatistics(t *testing.T) {
 		expectedResources = append(expectedResources, r.Resource)
 	}
 	for _, r := range testService.backend.Config().Relations {
-		resource := ""
-		if r.Resource != "" {
-			resource = r.Resource + ":" + resource
-		}
-		resource += r.Left + ":" + r.Right
-		expectedResources = append(expectedResources, resource)
+		expectedResources = append(expectedResources, r.Resource)
 	}
 	for _, r := range testService.backend.Config().Singletons {
 		expectedResources = append(expectedResources, r.Resource)

--- a/core/client/client_test.go
+++ b/core/client/client_test.go
@@ -34,6 +34,7 @@ func TestClient_TestClient(t *testing.T) {
 	parentID := uuid.MustParse("4f1638da-861e-4a81-8cc7-e6847b6fdf9b")
 	childID := uuid.MustParse("c46da255-eb72-4cc6-8835-1b34a9917826")
 	leftID := uuid.MustParse("4f1638da-861e-4a81-8cc7-e6847b6fdf9c")
+	rightID := uuid.MustParse("c46da255-eb72-4cc6-8835-1b34a9917827")
 
 	collection := client.Collection("parent/child")
 	if p := collection.CollectionPath(); p != "/parents/all/children" {
@@ -66,11 +67,20 @@ func TestClient_TestClient(t *testing.T) {
 		t.Fatal("unexpected collection path:", p)
 	}
 
-	collection = client.Relation("myrelation").Collection("left/right").WithParent(leftID)
-	if p := collection.CollectionPath(); p != "/myrelation/lefts/"+leftID.String()+"/rights" {
+	relationship := client.Collection("myrelation").Relationship(leftID, rightID)
+	if p := relationship.Path(); p != "/myrelations/"+leftID.String()+":"+rightID.String() {
+		t.Fatal("unexpected relationship path:", p)
+	}
+
+	collection = client.Collection("myrelation").WithLeft(leftID).WithRight(rightID)
+	if p := collection.CollectionPath(); p != "/myrelations?left="+leftID.String()+"&right="+rightID.String() {
 		t.Fatal("unexpected collection path:", p)
 	}
 
+	collection = client.Collection("myrelation").WithEither(leftID)
+	if p := collection.CollectionPath(); p != "/myrelations?either="+leftID.String() {
+		t.Fatal("unexpected collection path:", p)
+	}
 }
 func TestClient_Page_From(t *testing.T) {
 

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -37,6 +37,7 @@ var configurationJSON string = `
 	],
 	"relations": [
 	  {
+		"resource": "device_ownership",
 		"left": "user",
 		"right": "device"
 	  }

--- a/examples/fleet/fleet.go
+++ b/examples/fleet/fleet.go
@@ -32,34 +32,6 @@ var configurationJSON string = `{
 	  },
 	  {
 		"resource": "device/data"
-	  },
-	  {
-		"resource": "fleet"
-	  },
-	  {
-		"resource": "fleet/user"
-	  },
-	  {
-		"resource": "fleet/location"
-	  }
-	],
-	"singletons": [
-	  {
-		"resource": "fleet/user/profile"
-	  }
-	],
-	"relations": [
-	  {
-		"left": "device",
-		"right": "fleet"
-	  },
-	  {
-		"left": "fleet/location",
-		"right": "fleet/user"
-	  },
-	  {
-		"left": "fleet/device",
-		"right": "fleet/user"
 	  }
 	]
   }


### PR DESCRIPTION
Relations are a special type of collection, which creates a relation between two resources. For example, a relation "device_ownership" creates a relation between "user" on the left and "device" on the right.

The generated routes are as follows:

	/device_ownerships GET,PUT,PATCH,DELETE with optional query parameters ?left={user_id} and ?right={device_id}
	/device_ownerships/{users_id}:{device_id} GET,PUT,PATCH,DELETE

Like any other collection, relations support pagination, sorting and filtering.

It is also possible to have relations between the same type of resources, for example a relation "invitation" between "user" and "user". The generated routes are as follows:

	/invitations GET,PUT,PATCH,DELETE with optional query parameters ?left={inviting_user_id} and ?right={invited_user_id}
	/invitations/{inviting_user_id}:{invited_users_id} GET,PUT,PATCH,DELETE

You can also query all relations of a specific user regardless of wether they are the inviting user or the invited user:

	/invitations?either={user_id}

Relations between the same type of resource can also be non-directional, by specifying the "non_directional" to true in the configuration. For example the relation "friendship" between "user" and "user":

	/friendships GET,PUT,PATCH,DELETE with optional query parameters ?either={user_id}
	/friendships/{user_id}:{other_user_id} GET,PUT,PATCH,DELETE

The order between "user_id" and "other_user_id" does not matter. In the reported non-directional friendship object, one will be "left_user_id" and one will be "right_user_id", depending on the lexicographic order of the identifiers.