### PR TITLE
compress multiple update notifications for same resource into one

### DIFF
--- a/core/backend/backend.go
+++ b/core/backend/backend.go
@@ -42,7 +42,7 @@ var ConfigSchemaJSON string
 
 // InternalDatabaseSchemaVersion is a sequential versioning number of the database schema.
 // If it increases, the backend will try to update the schema.
-const InternalDatabaseSchemaVersion = 3
+const InternalDatabaseSchemaVersion = 4
 
 // Backend is the generic rest backend
 type Backend struct {

--- a/core/backend/backend_test.go
+++ b/core/backend/backend_test.go
@@ -1022,7 +1022,19 @@ func TestNotifications(t *testing.T) {
 	// do notification processing
 	backend.ProcessJobsSync(0)
 
-	// update child collection object with singleton path and 3 points
+	// now we do multiple updatees to child collection object with singleton path, but
+	// we do not process the queue, so they all should get coalesced into a single update
+	// notification
+
+	nsres["points"] = int64(42)
+	for range 10 {
+		_, err = client.RawPut("/notifications/"+nid+"/single", &nsres, &nsres)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// update child collection object one final time with singleton path and 3 points
 	nsres["points"] = int64(3)
 	_, err = client.RawPut("/notifications/"+nid+"/single", &nsres, &nsres)
 	if err != nil {
@@ -1050,7 +1062,7 @@ func TestNotifications(t *testing.T) {
 	if createCount != 4 {
 		t.Fatalf("unexpected number of creates: %d", createCount)
 	}
-	if updateCount != 4 {
+	if updateCount != 4 { // because 10 updates are overwritten and do not need to be handled
 		t.Fatalf("unexpected number of updates: %d", updateCount)
 	}
 	if deleteCount != 4 {

--- a/core/backend/jobs.go
+++ b/core/backend/jobs.go
@@ -125,6 +125,7 @@ func (b *Backend) handleJobs(router *mux.Router) {
 		PRIMARY KEY(serial)
 		);
 		CREATE UNIQUE INDEX IF NOT EXISTS $JUSTTABLENAME_event_compression ON $TABLENAME(type,key,resource,resource_id) WHERE job = 'event' AND attempts_left>0;
+		CREATE UNIQUE INDEX IF NOT EXISTS $JUSTTABLENAME_notification_compression ON $TABLENAME(type,key,resource,resource_id) WHERE job = 'notification' AND attempts_left>0;
 		CREATE index IF NOT EXISTS $JUSTTABLENAME_scheduled_at_index ON $TABLENAME(scheduled_at);
 		`)
 
@@ -1050,9 +1051,14 @@ func (b *Backend) commitWithNotification(ctx context.Context, tx *sql.Tx, resour
 
 	rlog.Debugf("commitWithNotification before: tx.QueryRow")
 	var serial int
-	err := tx.QueryRow("INSERT INTO "+b.db.Schema+".\"_job_\""+
-		"(job,type,resource,resource_id,payload,timestamp,attempts_left,context)"+
-		"VALUES('notification',$1,$2,$3,$4,$5,4,$6) RETURNING serial;",
+
+	query := "INSERT INTO " + b.db.Schema + ".\"_job_\"" +
+		`(job,type,resource,resource_id,payload,timestamp,attempts_left,context)
+	VALUES('notification',$1,$2,$3,$4,$5,5,$6) ON CONFLICT (type,key,resource,resource_id) WHERE job = 'notification' AND attempts_left>0
+	DO UPDATE SET payload=$4,timestamp=$5,attempts_left=5,context=$6
+	RETURNING serial;`
+
+	err := tx.QueryRow(query,
 		operation,
 		resource,
 		resourceID,


### PR DESCRIPTION
There is no reason to handle multiple update notifications, because later ones simply overwrite the object from before.