### PR TITLE
clarify and improve revision handling for upsert

### DIFF
--- a/core/backend/collection.go
+++ b/core/backend/collection.go
@@ -1982,7 +1982,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 			}
 		}
 
-		revision := 0
+		revision := -1
 		if r, ok := bodyJSON["revision"].(float64); ok {
 			revision = int(r)
 		}
@@ -2000,6 +2000,17 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 	Retry:
 		current, object := createScanValuesAndObject(&timestamp, &currentRevision)
 		err = tx.QueryRow(readQuery+"WHERE "+primary+"_id = $1 FOR UPDATE;", &primaryID).Scan(current...)
+		if revision >= 0 && revision != currentRevision {
+			tx.Rollback()
+			// revision does not match, return conflict status with the conflicting object
+			mergeProperties(object)
+			jsonData, _ := json.MarshalWithOption(object, json.DisableHTMLEscape())
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusConflict)
+			w.Write(jsonData)
+			return
+		}
+
 		if err == csql.ErrNoRows {
 			// item does not exist yet.
 			if singleton {
@@ -2041,16 +2052,6 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 			tx.Rollback()
 			rlog.WithError(err).Error("Error 4737: Rollback")
 			http.Error(w, "Error 4737", http.StatusInternalServerError)
-			return
-		}
-		if revision != 0 && revision != currentRevision {
-			tx.Rollback()
-			// revision does not match, return conflict status with the conflicting object
-			mergeProperties(object)
-			jsonData, _ := json.MarshalWithOption(object, json.DisableHTMLEscape())
-			w.Header().Set("Content-Type", "application/json; charset=utf-8")
-			w.WriteHeader(http.StatusConflict)
-			w.Write(jsonData)
 			return
 		}
 		mergeProperties(object)

--- a/core/backend/collection_test.go
+++ b/core/backend/collection_test.go
@@ -1718,3 +1718,112 @@ func TestListWithMultipleSearchFiltersInterceptor(t *testing.T) {
 	// Clean up
 	testService.client.Collection("a").Clear()
 }
+
+// TestUpsertWithRevision tests upserting a collection with revision handling
+func TestUpsertWithRevision(t *testing.T) {
+	jsonConfig := `{
+	"collections": [
+	  {
+		"resource": "a"
+	  }
+	],
+	"singletons": [],
+	"blobs": [],
+	"shortcuts": []
+  }
+`
+	testService := CreateTestService(jsonConfig, t.Name())
+	defer testService.Db.Close()
+
+	type A struct {
+		AId      uuid.UUID `json:"a_id"`
+		Text     string    `json:"text"`
+		Revision *int64    `json:"revision,omitempty"`
+	}
+
+	a := A{
+		AId:  uuid.New(),
+		Text: "Initial text",
+	}
+
+	_, err := testService.client.Collection("a").Upsert(a, &a)
+	assert.Nil(t, err)
+	assert.NotNil(t, a.Revision)
+	assert.Equal(t, int64(1), *a.Revision)
+
+	int64Ptr := func(i int64) *int64 { return &i }
+	aUpdate := A{
+		AId:      a.AId,
+		Text:     "Updated text",
+		Revision: int64Ptr(1),
+	}
+	_, err = testService.client.Collection("a").Upsert(aUpdate, &aUpdate)
+	assert.Nil(t, err)
+	assert.NotNil(t, aUpdate.Revision)
+	assert.Equal(t, int64(2), *aUpdate.Revision)
+
+	// Attempt to update with old revision - should fail
+	aConflict := A{
+		AId:      a.AId,
+		Text:     "Conflict text",
+		Revision: int64Ptr(1),
+	}
+	status, err := testService.client.Collection("a").Upsert(aConflict, &aConflict)
+	assert.NotNil(t, err)
+	assert.Equal(t, 409, status)
+
+	// Attempt to update with zero revision also fails
+	aZeroRevision := A{
+		AId:      a.AId,
+		Text:     "Zero revision text",
+		Revision: int64Ptr(0),
+	}
+	status, err = testService.client.Collection("a").Upsert(aZeroRevision, &aZeroRevision)
+	assert.NotNil(t, err)
+	assert.Equal(t, 409, status)
+
+	// Attempt to update with no revision succeeds
+	aNoRevision := A{
+		AId:  a.AId,
+		Text: "No revision update",
+	}
+	_, err = testService.client.Collection("a").Upsert(aNoRevision, &aNoRevision)
+	assert.Nil(t, err)
+	assert.NotNil(t, aNoRevision.Revision)
+	assert.Equal(t, int64(3), *aNoRevision.Revision)
+
+	// Attempt to update with negative revision succeeds
+	aNegativeRevision := A{
+		AId:      a.AId,
+		Text:     "Negative revision text",
+		Revision: int64Ptr(-1),
+	}
+	_, err = testService.client.Collection("a").Upsert(aNegativeRevision, &aNegativeRevision)
+	assert.Nil(t, err)
+	assert.NotNil(t, aNegativeRevision.Revision)
+	assert.Equal(t, int64(4), *aNegativeRevision.Revision)
+
+	// Attempt to create new item with specific revision fails because item doesn't exist
+	aNewWithRevision := A{
+		AId:      uuid.New(),
+		Text:     "New item with revision",
+		Revision: int64Ptr(1),
+	}
+	status, err = testService.client.Collection("a").Upsert(aNewWithRevision, &aNewWithRevision)
+	assert.NotNil(t, err)
+	assert.Equal(t, 409, status)
+
+	// Attempt to create new item with revision zero works
+	aNewZeroRevision := A{
+		AId:      uuid.New(),
+		Text:     "New item with zero revision",
+		Revision: int64Ptr(0),
+	}
+	_, err = testService.client.Collection("a").Upsert(aNewZeroRevision, &aNewZeroRevision)
+	assert.Nil(t, err)
+	assert.NotNil(t, aNewZeroRevision.Revision)
+	assert.Equal(t, int64(1), *aNewZeroRevision.Revision)
+
+	// Clean up remaining items
+	testService.client.Collection("a").Clear()
+}

--- a/core/backend/doc.go
+++ b/core/backend/doc.go
@@ -183,9 +183,10 @@ you would simply query /user/devices.
 
 Every item has an integer property "revision", which is incremented every time the item is updated. Revisions can be
 used to make updates safe in systems with multiple concurrent writers. If a PUT or PATCH request contains a
-non-zero revision number which does not match the item's current revision, then the request is discarded and
-the conflicting newer version of the object is returned with an error status (409 - Conflict).
-A PUT or PATCH request with a revision of zero, or no revision at all, will not be checked for possible conflicts.
+non-negative revision number which does not match the item's current revision, then the request is discarded and
+the conflicting newer version of the object is returned with an error status (409 - Conflict). Passing zero as revision
+number guarantees that the item will only be created if it does not exist yet, but it will not update an existing item.
+A PUT or PATCH request with a negative revision , or no revision at all, will not be checked for possible conflicts.
 
 # Wildcard Queries
 

--- a/core/backend/relation.go
+++ b/core/backend/relation.go
@@ -1793,11 +1793,10 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 			return
 		}
 
-		revision := 0
+		revision := -1
 		if r, ok := bodyJSON["revision"].(float64); ok {
 			revision = int(r)
 		}
-
 		tx, err := b.db.BeginTx(r.Context(), nil)
 		if err != nil {
 			rlog.WithError(err).Errorf("Error 4736: Update of resource `%s`", resource)
@@ -1811,6 +1810,17 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 	Retry:
 		current, object := createScanValuesAndObject(&timestamp, &currentRevision)
 		err = tx.QueryRow(readQuery+"WHERE "+leftColumn+" = $1 AND "+rightColumn+" = $2 FOR UPDATE;", &leftID, &rightID).Scan(current...)
+		if revision >= 0 && revision != currentRevision {
+			tx.Rollback()
+			// revision does not match, return conflict status with the conflicting object
+			mergeProperties(object)
+			jsonData, _ := json.MarshalWithOption(object, json.DisableHTMLEscape())
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusConflict)
+			w.Write(jsonData)
+			return
+		}
+
 		if err == csql.ErrNoRows {
 			// item does not exist yet.
 			if r.Method == http.MethodPatch {
@@ -1852,7 +1862,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 			http.Error(w, "Error 4737", http.StatusInternalServerError)
 			return
 		}
-		if revision != 0 && revision != currentRevision {
+		if revision >= 0 && revision != currentRevision {
 			tx.Rollback()
 			// revision does not match, return conflict status with the conflicting object
 			mergeProperties(object)

--- a/core/backend/relation_test.go
+++ b/core/backend/relation_test.go
@@ -773,7 +773,7 @@ func TestRelationRevision(t *testing.T) {
 		LeftAID  uuid.UUID `json:"left_a_id"`
 		RightAID uuid.UUID `json:"right_a_id"`
 		Text     string    `json:"text,omitempty"`
-		Revision int       `json:"revision,omitempty"`
+		Revision int       `json:"revision"`
 	}
 
 	// First we create an a
@@ -792,14 +792,27 @@ func TestRelationRevision(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Then we create a relation between a1 and a2. We use revision -1 which means "create only"
+	// Then we try to create a relation between a1 and a2 with a specific revision, which will fail because
+	// the relation does not exist yet
 	relation := MyRelation{
 		LeftAID:  a1.AID,
 		RightAID: a2.AID,
-		Text:     "revision 1",
-		Revision: -1,
+		Text:     "revision 42",
+		Revision: 42,
 	}
 	status, err := adminClient.RawPut("/a_a_relations", &relation, nil)
+	if status != http.StatusConflict || err == nil {
+		t.Fatalf("Expecting conflict, got %v (%v)", status, err)
+	}
+
+	// Then we actually create a relation between a1 and a2. We use revision zero which means "create only"
+	relation = MyRelation{
+		LeftAID:  a1.AID,
+		RightAID: a2.AID,
+		Text:     "revision 1",
+		Revision: 0,
+	}
+	status, err = adminClient.RawPut("/a_a_relations", &relation, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -807,12 +820,12 @@ func TestRelationRevision(t *testing.T) {
 		t.Fatalf("Expecting created, got %v", status)
 	}
 
-	// Updating the relation with revision -1 will fail
+	// Updating the relation with revision zero will fail
 	relation = MyRelation{
 		LeftAID:  a1.AID,
 		RightAID: a2.AID,
 		Text:     "revision 2",
-		Revision: -1,
+		Revision: 0,
 	}
 	status, err = adminClient.RawPut("/a_a_relations", &relation, nil)
 	if status != http.StatusConflict || err == nil {
@@ -824,19 +837,19 @@ func TestRelationRevision(t *testing.T) {
 		LeftAID:  a2.AID,
 		RightAID: a1.AID,
 		Text:     "revision 2",
-		Revision: -1,
+		Revision: 0,
 	}
 	status, err = adminClient.RawPut("/a_a_relations", &relation, nil)
 	if status != http.StatusConflict || err == nil {
 		t.Fatalf("Expecting conflict, got %v (%v)", status, err)
 	}
 
-	// Now we update it with revision 0, which is the revision that ALWAYS works
+	// Now we update it with revision -1, which is the revision that ALWAYS works
 	relation = MyRelation{
 		LeftAID:  a1.AID,
 		RightAID: a2.AID,
 		Text:     "revision 2",
-		Revision: 0,
+		Revision: -1,
 	}
 	var result MyRelation
 	status, err = adminClient.RawPut("/a_a_relations", &relation, &result)

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -786,7 +786,7 @@ func (c Client) RawGet(path string, result interface{}) (int, error) {
 		}
 		res, err = c.httpClient.Do(r)
 		if err != nil {
-			return http.StatusInternalServerError, err
+			return res.StatusCode, err
 		}
 		defer res.Body.Close()
 		resBody, _ = io.ReadAll(res.Body)
@@ -842,7 +842,7 @@ func (c Client) RawGetWithHeader(path string, header map[string]string, result i
 		}
 		res, err = c.httpClient.Do(r)
 		if err != nil {
-			return http.StatusInternalServerError, nil, err
+			return res.StatusCode, nil, err
 		}
 		defer res.Body.Close()
 		resBody, _ = io.ReadAll(res.Body)
@@ -897,7 +897,7 @@ func (c *Client) RawGetBlobWithHeader(path string, header map[string]string, blo
 		}
 		res, err = c.httpClient.Do(r)
 		if err != nil {
-			return http.StatusInternalServerError, nil, err
+			return res.StatusCode, nil, err
 		}
 		defer res.Body.Close()
 		resBody, _ = io.ReadAll(res.Body)
@@ -962,7 +962,7 @@ func (c Client) RawPostWithHeader(path string, headers map[string]string, body i
 		}
 		res, err = c.httpClient.Do(r)
 		if err != nil {
-			return http.StatusInternalServerError, err
+			return res.StatusCode, err
 		}
 		defer res.Body.Close()
 		resBody, _ = io.ReadAll(res.Body)
@@ -1027,7 +1027,7 @@ func (c Client) RawPostBlob(path string, header map[string]string, blob []byte, 
 		}
 		res, err = c.httpClient.Do(r)
 		if err != nil {
-			return http.StatusInternalServerError, err
+			return res.StatusCode, err
 		}
 		defer res.Body.Close()
 		resBody, _ = io.ReadAll(res.Body)
@@ -1086,7 +1086,7 @@ func (c Client) RawPut(path string, body interface{}, result interface{}) (int, 
 		}
 		res, err = c.httpClient.Do(r)
 		if err != nil {
-			return http.StatusInternalServerError, err
+			return res.StatusCode, err
 		}
 		defer res.Body.Close()
 		resBody, _ = io.ReadAll(res.Body)
@@ -1141,7 +1141,7 @@ func (c Client) RawPutBlob(path string, header map[string]string, blob []byte, r
 		}
 		res, err = c.httpClient.Do(r)
 		if err != nil {
-			return http.StatusInternalServerError, err
+			return res.StatusCode, err
 		}
 		defer res.Body.Close()
 		resBody, _ = io.ReadAll(res.Body)
@@ -1197,7 +1197,7 @@ func (c Client) RawPatch(path string, body interface{}, result interface{}) (int
 		}
 		res, err = c.httpClient.Do(r)
 		if err != nil {
-			return http.StatusInternalServerError, err
+			return res.StatusCode, err
 		}
 		defer res.Body.Close()
 		resBody, _ = io.ReadAll(res.Body)
@@ -1242,7 +1242,7 @@ func (c Client) RawDelete(path string) (int, error) {
 		}
 		res, err = c.httpClient.Do(r)
 		if err != nil {
-			return http.StatusInternalServerError, err
+			return res.StatusCode, err
 		}
 		defer res.Body.Close()
 		resBody, _ = io.ReadAll(res.Body)


### PR DESCRIPTION
no revision or revision < 0: no version check

revision >= 0: revision must match

Revision 0 thus enforces object creation. If an
object already exists, it will fail with 409 conflict.