### PR TITLE
Nullable static and searchable properties

### DIFF
--- a/core/backend/backend.go
+++ b/core/backend/backend.go
@@ -42,7 +42,7 @@ var ConfigSchemaJSON string
 
 // InternalDatabaseSchemaVersion is a sequential versioning number of the database schema.
 // If it increases, the backend will try to update the schema.
-const InternalDatabaseSchemaVersion = 4
+const InternalDatabaseSchemaVersion = 5
 
 // Backend is the generic rest backend
 type Backend struct {

--- a/core/backend/backend.go
+++ b/core/backend/backend.go
@@ -599,6 +599,7 @@ func (b *Backend) DidUpdateSchema() bool {
 	return b.updateSchema
 }
 
+/*
 func debugQuery(query string, args ...any) string {
 	for r := range args {
 		i := len(args) - r - 1 // start with last parameter in case we have more than $9 in the query
@@ -616,3 +617,4 @@ func debugQuery(query string, args ...any) string {
 	}
 	return query
 }
+*/

--- a/core/backend/backend.go
+++ b/core/backend/backend.go
@@ -42,7 +42,7 @@ var ConfigSchemaJSON string
 
 // InternalDatabaseSchemaVersion is a sequential versioning number of the database schema.
 // If it increases, the backend will try to update the schema.
-const InternalDatabaseSchemaVersion = 5
+const InternalDatabaseSchemaVersion = 6
 
 // Backend is the generic rest backend
 type Backend struct {

--- a/core/backend/backend_test.go
+++ b/core/backend/backend_test.go
@@ -245,12 +245,6 @@ type A struct {
 func ptrString(s string) *string {
 	return &s
 }
-func saveString(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
 func TestCollectionA(t *testing.T) {
 	testService := CreateTestService(configurationJSON, t.Name())
 	defer testService.Db.Close()

--- a/core/backend/backend_test.go
+++ b/core/backend/backend_test.go
@@ -43,7 +43,7 @@ var configurationJSON string = `{
 		"resource": "a",
 		"external_index": "external_id",
 		"static_properties": ["static_prop"],
-		"searchable_properties": ["searchable_prop", "other_searchable_prop"]
+		"searchable_properties": ["searchable_prop", "optional_searchable_prop"]
 	  },
 	  {
 		"resource": "b",
@@ -233,24 +233,35 @@ func TestMain(m *testing.M) {
 }
 
 type A struct {
-	AID                 uuid.UUID `json:"a_id"`
-	ExternalID          string    `json:"external_id"`
-	StaticProp          string    `json:"static_prop"`
-	SearchableProp      string    `json:"searchable_prop"`
-	OtherSearchableProp string    `json:"other_searchable_prop"`
-	Timestamp           time.Time `json:"timestamp"`
-	Foo                 string    `json:"foo"`
+	AID                    uuid.UUID `json:"a_id"`
+	ExternalID             string    `json:"external_id"`
+	StaticProp             string    `json:"static_prop"`
+	SearchableProp         string    `json:"searchable_prop"`
+	OptionalSearchableProp *string   `json:"optional_searchable_prop,omitempty"`
+	Timestamp              time.Time `json:"timestamp"`
+	Foo                    string    `json:"foo"`
 }
 
+func ptrString(s string) *string {
+	return &s
+}
+func saveString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
 func TestCollectionA(t *testing.T) {
+	testService := CreateTestService(configurationJSON, t.Name())
+	defer testService.Db.Close()
 
 	aNew := A{
-		Foo:                 "bar",
-		ExternalID:          "external",
-		StaticProp:          "static",
-		SearchableProp:      "searchable",
-		OtherSearchableProp: "other",
-		Timestamp:           time.Now().UTC().Round(time.Millisecond), // round to postgres precision
+		Foo:                    "bar",
+		ExternalID:             "external",
+		StaticProp:             "static",
+		SearchableProp:         "searchable",
+		OptionalSearchableProp: ptrString("optional"),
+		Timestamp:              time.Now().UTC().Round(time.Millisecond), // round to postgres precision
 	}
 
 	a := A{}
@@ -339,7 +350,7 @@ func TestCollectionA(t *testing.T) {
 		t.Fatal("unexpected number of items in collection, expected only 2:", asJSON(collectionResult))
 	}
 
-	// we now search for the searachable property and should only find our single item a
+	// we now search for the searchable property and should only find our single item a
 	_, err = testService.client.RawGet("/as?filter=searchable_prop=searchable", &collectionResult)
 	if err != nil {
 		t.Fatal(err)
@@ -351,8 +362,8 @@ func TestCollectionA(t *testing.T) {
 		t.Fatal("wrong item in collection:", asJSON(collectionResult))
 	}
 
-	// we now search for the searachable property with secondary filter and should find nothing
-	_, err = testService.client.RawGet("/as?filter=searchable_prop=searchable&filter=other_searchable_prop=fail", &collectionResult)
+	// we now search for the searchable property with secondary filter and should find nothing
+	_, err = testService.client.RawGet("/as?filter=searchable_prop=searchable&filter=optional_searchable_prop=fail", &collectionResult)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,8 +371,8 @@ func TestCollectionA(t *testing.T) {
 		t.Fatal("unexpected number of items in collection, expected only 0:", asJSON(collectionResult))
 	}
 
-	// we now search for the searachable property with correct secondary filter and should only find our single item a
-	_, err = testService.client.RawGet("/as?filter=searchable_prop=searchable&filter=other_searchable_prop=other", &collectionResult)
+	// we now search for the searchable property with correct secondary filter and should only find our single item a
+	_, err = testService.client.RawGet("/as?filter=searchable_prop=searchable&filter=optional_searchable_prop=optional", &collectionResult)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1314,6 +1325,9 @@ func TestResourceDefaults(t *testing.T) {
 }
 
 func TestPaginationCollection(t *testing.T) {
+	testService := CreateTestService(configurationJSON, t.Name())
+	defer testService.Db.Close()
+
 	// Populate the DB with elements created at two timestamps
 	numberOfElements := 210
 	timestampFirst50 := time.Now().UTC().Round(time.Millisecond)

--- a/core/backend/collection.go
+++ b/core/backend/collection.go
@@ -169,12 +169,14 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 	// static properties are varchars
 	for _, property := range rc.StaticProperties {
 		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar DEFAULT NULL;", schema, resource, property)
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ALTER COLUMN \"%s\" DROP NOT NULL;", schema, resource, property) // compatibility with schemata <= 4
 		columns = append(columns, property)
 	}
 
 	// static searchable properties are varchars with a non-unique index
 	for _, property := range rc.SearchableProperties {
 		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar DEFAULT NULL;", schema, resource, property)
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ALTER COLUMN \"%s\" DROP NOT NULL;", schema, resource, property) // compatibility with schemata <= 4
 		createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"searchable_property_"+this+"_"+property,
 			schema, resource, property, property, property)
@@ -204,6 +206,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 		createIndicesQuery += fmt.Sprintf("CREATE UNIQUE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"external_index_"+this+"_"+name,
 			schema, resource, name, name, name)
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ALTER COLUMN \"%s\" DROP NOT NULL;", schema, resource, name) // compatibility with schemata <= 4
 		// the log index is not unique
 		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"external_index_"+this+"_"+name,

--- a/core/backend/collection.go
+++ b/core/backend/collection.go
@@ -144,8 +144,48 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 	}
 
 	createColumns = append(createColumns, "properties json NOT NULL DEFAULT '{}'::jsonb")
+
 	// query to create all indices after the table creation
-	createIndicesQuery := fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(timestamp);",
+	var createIndicesQuery string
+
+	if singleton {
+		// singletons do not have a primary id, hence we missed the main index.
+		// the code here creates a unique index and at the same time handles
+		// migration by deduplicating existing entries if there are any
+		singletonIndexName := "uq_" + this + "_" + owner + "_id"
+		singletonIndex := fmt.Sprintf(
+			`DO $$
+BEGIN
+  BEGIN
+    EXECUTE '
+      CREATE UNIQUE INDEX IF NOT EXISTS %s
+      ON %s."%s"(%s_id)
+    ';
+  EXCEPTION
+    WHEN unique_violation THEN
+      DELETE FROM %s."%s" a
+      USING %s."%s" b
+      WHERE a.%s_id = b.%s_id
+        AND a.ctid > b.ctid;
+      EXECUTE '
+        CREATE UNIQUE INDEX IF NOT EXISTS %s
+        ON %s."%s"(%s_id)
+      ';
+  END;
+END
+$$;`,
+			singletonIndexName,
+			schema, resource, owner,
+			schema, resource,
+			schema, resource,
+			owner, owner,
+			singletonIndexName,
+			schema, resource, owner)
+
+		createIndicesQuery += singletonIndex
+	}
+
+	createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(timestamp);",
 		"sort_index_"+this+"_timestamp",
 		schema, resource)
 

--- a/core/backend/collection.go
+++ b/core/backend/collection.go
@@ -181,17 +181,17 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 			"searchable_property_"+this+"_"+property,
 			schema, resource, property, property, property)
 		if len(majorSearchColumns) > 0 {
-			createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s,%s) WHERE %s IS NOT NULL AND %s <> '';",
+			createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s,%s);",
 				"searchable_property_"+this+"_"+property+"_"+strings.Join(majorSearchColumns, "_"),
-				schema, resource, property, strings.Join(majorSearchColumns, ","), property, property)
+				schema, resource, property, strings.Join(majorSearchColumns, ","))
 		}
 		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"searchable_property_"+this+"_"+property,
 			schema, resource, property, property, property)
 		if len(majorSearchColumns) > 0 {
-			createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s,%s) WHERE %s IS NOT NULL AND %s <> '';",
+			createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s,%s);",
 				"searchable_property_"+this+"_"+property+"_"+strings.Join(majorSearchColumns, "_"),
-				schema, resource, property, strings.Join(majorSearchColumns, ","), property, property)
+				schema, resource, property, strings.Join(majorSearchColumns, ","))
 		}
 		columns = append(columns, property)
 		searchableColumns = append(searchableColumns, property)
@@ -203,14 +203,15 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 	if len(rc.ExternalIndex) > 0 {
 		name := rc.ExternalIndex
 		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar DEFAULT NULL;", schema, resource, name)
+		createIndicesQuery += fmt.Sprintf("DROP index IF EXISTS %s;", "external_index_"+this+"_"+name)
 		createIndicesQuery += fmt.Sprintf("CREATE UNIQUE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
-			"external_index_"+this+"_"+name,
+			"unique_property_"+this+"_"+name,
 			schema, resource, name, name, name)
 		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ALTER COLUMN \"%s\" DROP NOT NULL;", schema, resource, name) // compatibility with schemata <= 4
 		// the log index is not unique
-		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
-			"external_index_"+this+"_"+name,
-			schema, resource, name, name, name)
+		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s);",
+			"unique_property_"+this+"_"+name,
+			schema, resource, name)
 		columns = append(columns, name)
 		searchableColumns = append(searchableColumns, name)
 	}

--- a/core/backend/collection.go
+++ b/core/backend/collection.go
@@ -178,9 +178,19 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 		createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"searchable_property_"+this+"_"+property,
 			schema, resource, property, property, property)
+		if len(majorSearchColumns) > 0 {
+			createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s,%s) WHERE %s IS NOT NULL AND %s <> '';",
+				"searchable_property_"+this+"_"+property+"_"+strings.Join(majorSearchColumns, "_"),
+				schema, resource, property, strings.Join(majorSearchColumns, ","), property, property)
+		}
 		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"searchable_property_"+this+"_"+property,
 			schema, resource, property, property, property)
+		if len(majorSearchColumns) > 0 {
+			createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s,%s) WHERE %s IS NOT NULL AND %s <> '';",
+				"searchable_property_"+this+"_"+property+"_"+strings.Join(majorSearchColumns, "_"),
+				schema, resource, property, strings.Join(majorSearchColumns, ","), property, property)
+		}
 		columns = append(columns, property)
 		searchableColumns = append(searchableColumns, property)
 	}

--- a/core/backend/collection.go
+++ b/core/backend/collection.go
@@ -9,6 +9,7 @@ package backend
 import (
 	"compress/gzip"
 	"context"
+	"database/sql"
 	"fmt"
 	"net"
 	"slices"
@@ -167,19 +168,19 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 	staticPropertiesIndex := len(columns) // where static properties start
 	// static properties are varchars
 	for _, property := range rc.StaticProperties {
-		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar NOT NULL DEFAULT '';", schema, resource, property)
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar DEFAULT NULL;", schema, resource, property)
 		columns = append(columns, property)
 	}
 
 	// static searchable properties are varchars with a non-unique index
 	for _, property := range rc.SearchableProperties {
-		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar NOT NULL DEFAULT '';", schema, resource, property)
-		createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s);",
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar DEFAULT NULL;", schema, resource, property)
+		createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"searchable_property_"+this+"_"+property,
-			schema, resource, property)
-		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s);",
+			schema, resource, property, property, property)
+		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"searchable_property_"+this+"_"+property,
-			schema, resource, property)
+			schema, resource, property, property, property)
 		columns = append(columns, property)
 		searchableColumns = append(searchableColumns, property)
 	}
@@ -189,14 +190,14 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 	// an external index is a unique varchar property.
 	if len(rc.ExternalIndex) > 0 {
 		name := rc.ExternalIndex
-		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar NOT NULL DEFAULT '';", schema, resource, name)
-		createIndicesQuery += fmt.Sprintf("CREATE UNIQUE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s <> '';",
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar DEFAULT NULL;", schema, resource, name)
+		createIndicesQuery += fmt.Sprintf("CREATE UNIQUE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"external_index_"+this+"_"+name,
-			schema, resource, name, name)
+			schema, resource, name, name, name)
 		// the log index is not unique
-		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s);",
+		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"external_index_"+this+"_"+name,
-			schema, resource, name)
+			schema, resource, name, name, name)
 		columns = append(columns, name)
 		searchableColumns = append(searchableColumns, name)
 	}
@@ -330,9 +331,9 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 		i++
 
 		for ; i < len(columns); i++ {
-			str := ""
-			values[i] = &str
-			object[columns[i]] = values[i]
+			nullStr := &sql.NullString{}
+			values[i] = nullStr
+			object[columns[i]] = nullStr
 
 		}
 
@@ -343,6 +344,20 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 		object["revision"] = revision
 		values = append(values, extra...)
 		return values, object
+	}
+
+	normalizeNullableStrings := func(object map[string]interface{}) {
+		for key, value := range object {
+			nullStr, ok := value.(*sql.NullString)
+			if !ok {
+				continue
+			}
+			if nullStr.Valid {
+				object[key] = nullStr.String
+			} else {
+				object[key] = nil
+			}
+		}
 	}
 
 	createScanValuesAndObjectMeta := func(timestamp *time.Time, revision *int, extra ...interface{}) ([]interface{}, map[string]interface{}) {
@@ -651,6 +666,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 			lastTimestamp = timestamp
 			lastID = *values[0].(*uuid.UUID) // First value is always the ID
 			if !metaonly {
+				normalizeNullableStrings(object)
 				var uploadURL string
 				if rc.WithCompanionFile && withCompanionUrls && b.KssDriver != nil {
 					var key string
@@ -939,6 +955,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 			rowCount++
 
 			if !metaonly {
+				normalizeNullableStrings(object)
 				var uploadURL string
 				if rc.WithCompanionFile && withCompanionUrls && b.KssDriver != nil {
 					var key string
@@ -1131,6 +1148,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 			http.Error(w, "Error 4727", status)
 			return
 		}
+		normalizeNullableStrings(object)
 		mergeProperties(object)
 
 		// apply defaults if applicable
@@ -1402,6 +1420,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 			}
 		}
 
+		normalizeNullableStrings(object)
 		mergeProperties(object)
 		jsonData, _ := json.MarshalWithOption(object, json.DisableHTMLEscape())
 
@@ -1787,7 +1806,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 		for ; i < len(columns); i++ {
 			value, ok := bodyJSON[columns[i]]
 			if !ok {
-				value = ""
+				value = nil
 			}
 			values[i] = value
 		}
@@ -1881,6 +1900,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 			}
 		}
 
+		normalizeNullableStrings(object)
 		mergeProperties(object)
 		jsonData, _ = json.MarshalWithOption(object, json.DisableHTMLEscape())
 
@@ -2003,6 +2023,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 		if revision >= 0 && revision != currentRevision {
 			tx.Rollback()
 			// revision does not match, return conflict status with the conflicting object
+			normalizeNullableStrings(object)
 			mergeProperties(object)
 			jsonData, _ := json.MarshalWithOption(object, json.DisableHTMLEscape())
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -2054,6 +2075,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 			http.Error(w, "Error 4737", http.StatusInternalServerError)
 			return
 		}
+		normalizeNullableStrings(object)
 		mergeProperties(object)
 
 		primaryUUID := *current[0].(*uuid.UUID)
@@ -2220,6 +2242,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 			http.Error(w, "Error 4740", http.StatusInternalServerError)
 			return
 		}
+		normalizeNullableStrings(response)
 		mergeProperties(response)
 		jsonData, _ = json.MarshalWithOption(response, json.DisableHTMLEscape())
 

--- a/core/backend/collection.go
+++ b/core/backend/collection.go
@@ -177,17 +177,17 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 	for _, property := range rc.SearchableProperties {
 		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar DEFAULT NULL;", schema, resource, property)
 		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ALTER COLUMN \"%s\" DROP NOT NULL;", schema, resource, property) // compatibility with schemata <= 4
-		createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
+		createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s);",
 			"searchable_property_"+this+"_"+property,
-			schema, resource, property, property, property)
+			schema, resource, property)
 		if len(majorSearchColumns) > 0 {
 			createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s,%s);",
 				"searchable_property_"+this+"_"+property+"_"+strings.Join(majorSearchColumns, "_"),
 				schema, resource, property, strings.Join(majorSearchColumns, ","))
 		}
-		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
+		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s);",
 			"searchable_property_"+this+"_"+property,
-			schema, resource, property, property, property)
+			schema, resource, property)
 		if len(majorSearchColumns) > 0 {
 			createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s,%s);",
 				"searchable_property_"+this+"_"+property+"_"+strings.Join(majorSearchColumns, "_"),

--- a/core/backend/collection.go
+++ b/core/backend/collection.go
@@ -197,8 +197,6 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 		searchableColumns = append(searchableColumns, property)
 	}
 
-	propertiesEndIndex := len(columns) // where properties end
-
 	// an external index is a unique varchar property.
 	if len(rc.ExternalIndex) > 0 {
 		name := rc.ExternalIndex
@@ -215,6 +213,8 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 		columns = append(columns, name)
 		searchableColumns = append(searchableColumns, name)
 	}
+
+	propertiesEndIndex := len(columns) // where properties end
 
 	// the "device" collection gets an additional UUID column for the web token
 	if this == "device" {
@@ -2212,7 +2212,7 @@ func (b *Backend) createCollectionResource(router *mux.Router, rc CollectionConf
 
 		for ; i < len(columns); i++ {
 			value, ok := bodyJSON[columns[i]]
-			if !ok {
+			if !ok && i < staticPropertiesIndex { // static properties and external indices are non mandatory, we can update them to null
 				tx.Rollback()
 				http.Error(w, "missing property or index "+columns[i], http.StatusBadRequest)
 				return

--- a/core/backend/collection_test.go
+++ b/core/backend/collection_test.go
@@ -242,6 +242,21 @@ func TestCollectionExternalID(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, status, err)
 }
 
+func TestCollectionOptionalSearchableProperty(t *testing.T) {
+	a := A{}
+	// point here is that we do not set a value for the optional searchable property, and yet
+	// we can do an upsert using put
+	_, err := testService.client.RawPost("/as", a, &a)
+	assert.Nil(t, err)
+	a.Foo = "updated"
+	var result A
+	_, err = testService.client.RawPut("/as/"+a.AID.String(), a, &result)
+	assert.Nil(t, err)
+	assert.Equal(t, a.Foo, result.Foo)
+	_, err = testService.client.RawDelete("/as/" + result.AID.String())
+	assert.Nil(t, err)
+}
+
 func TestCollectionWithSchemaValidation(t *testing.T) {
 	type withSchema struct {
 		WithSchemaID uuid.UUID `json:"with_schema_id"`
@@ -734,6 +749,9 @@ func TestPatch(t *testing.T) {
 }
 
 func TestCursorPaginationCollection(t *testing.T) {
+	testService := CreateTestService(configurationJSON, t.Name())
+	defer testService.Db.Close()
+
 	// Clear any existing data
 	_, err := testService.client.RawDelete("/as")
 	if err != nil {
@@ -798,6 +816,9 @@ func TestCursorPaginationCollection(t *testing.T) {
 }
 
 func TestCursorPaginationMutualExclusion(t *testing.T) {
+	testService := CreateTestService(configurationJSON, t.Name())
+	defer testService.Db.Close()
+
 	// Test that page and next_token are mutually exclusive
 	cursor := backend.PaginationCursor{
 		Timestamp: time.Now().UTC(),
@@ -814,6 +835,9 @@ func TestCursorPaginationMutualExclusion(t *testing.T) {
 }
 
 func TestCursorPaginationInvalidToken(t *testing.T) {
+	testService := CreateTestService(configurationJSON, t.Name())
+	defer testService.Db.Close()
+
 	// Test invalid cursor format
 	path := "/as?next_token=invalid_token"
 	var as []A
@@ -825,6 +849,9 @@ func TestCursorPaginationInvalidToken(t *testing.T) {
 }
 
 func TestCursorPaginationCollectionWithOrdering(t *testing.T) {
+	testService := CreateTestService(configurationJSON, t.Name())
+	defer testService.Db.Close()
+
 	// Clear any existing data
 	_, err := testService.client.RawDelete("/as")
 	if err != nil {
@@ -953,6 +980,9 @@ func TestCursorPaginationCollectionWithOrdering(t *testing.T) {
 }
 
 func TestCursorPaginationCollectionEmptyCollection(t *testing.T) {
+	testService := CreateTestService(configurationJSON, t.Name())
+	defer testService.Db.Close()
+
 	// Clear any existing data
 	_, err := testService.client.RawDelete("/as")
 	if err != nil {
@@ -972,6 +1002,9 @@ func TestCursorPaginationCollectionEmptyCollection(t *testing.T) {
 }
 
 func TestCursorPaginationCollectionWithTimeFiltering(t *testing.T) {
+	testService := CreateTestService(configurationJSON, t.Name())
+	defer testService.Db.Close()
+
 	// Clear any existing data
 	_, err := testService.client.RawDelete("/as")
 	if err != nil {
@@ -1029,6 +1062,9 @@ func TestCursorPaginationCollectionWithTimeFiltering(t *testing.T) {
 }
 
 func TestCursorPaginationWithDeletionAndReplacement(t *testing.T) {
+	testService := CreateTestService(configurationJSON, t.Name())
+	defer testService.Db.Close()
+
 	// Clear any existing data
 	_, err := testService.client.RawDelete("/as")
 	if err != nil {
@@ -1055,7 +1091,7 @@ func TestCursorPaginationWithDeletionAndReplacement(t *testing.T) {
 
 	// Test with ascending order
 	t.Run("ascending_order", func(t *testing.T) {
-		testCursorPaginationWithDeletionAndReplacementHelper(t, "asc", initialElements, "asc")
+		testCursorPaginationWithDeletionAndReplacementHelper(t, testService, "asc", initialElements, "asc")
 
 		// Clean up after ascending test
 		_, err = testService.client.RawDelete("/as")
@@ -1079,12 +1115,12 @@ func TestCursorPaginationWithDeletionAndReplacement(t *testing.T) {
 
 	// Test with descending order
 	t.Run("descending_order", func(t *testing.T) {
-		testCursorPaginationWithDeletionAndReplacementHelper(t, "desc", initialElements, "desc")
+		testCursorPaginationWithDeletionAndReplacementHelper(t, testService, "desc", initialElements, "desc")
 	})
 
 }
 
-func testCursorPaginationWithDeletionAndReplacementHelper(t *testing.T, order string, initialElements []A, testPrefix string) {
+func testCursorPaginationWithDeletionAndReplacementHelper(t *testing.T, testService *TestService, order string, initialElements []A, testPrefix string) {
 	limit := 10
 	var allFetchedElements []A
 	var nextToken string
@@ -1306,10 +1342,10 @@ func TestClearWithMultipleFilters(t *testing.T) {
 
 	// Create test data
 	testData := []A{
-		{ExternalID: "ext_1", SearchableProp: "search_a", OtherSearchableProp: "other_a", Foo: "foo_1"},
-		{ExternalID: "ext_2", SearchableProp: "search_a", OtherSearchableProp: "other_b", Foo: "foo_1"},
-		{ExternalID: "ext_3", SearchableProp: "search_b", OtherSearchableProp: "other_a", Foo: "foo_2"},
-		{ExternalID: "ext_4", SearchableProp: "search_b", OtherSearchableProp: "other_b", Foo: "foo_2"},
+		{ExternalID: "ext_1", SearchableProp: "search_a", OptionalSearchableProp: ptrString("other_a"), Foo: "foo_1"},
+		{ExternalID: "ext_2", SearchableProp: "search_a", OptionalSearchableProp: ptrString("other_b"), Foo: "foo_1"},
+		{ExternalID: "ext_3", SearchableProp: "search_b", OptionalSearchableProp: ptrString("other_a"), Foo: "foo_2"},
+		{ExternalID: "ext_4", SearchableProp: "search_b", OptionalSearchableProp: ptrString("other_b"), Foo: "foo_2"},
 	}
 
 	for _, a := range testData {
@@ -1682,7 +1718,7 @@ func TestListWithMultipleSearchFiltersInterceptor(t *testing.T) {
 
 	// Create test data
 	testData := []A{
-		{ExternalID: "ext_1", SearchableProp: "value_a", OtherSearchableProp: "other_a"},
+		{ExternalID: "ext_1", SearchableProp: "value_a", OptionalSearchableProp: ptrString("other_a")},
 	}
 
 	for _, a := range testData {

--- a/core/backend/relation.go
+++ b/core/backend/relation.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"slices"
@@ -146,39 +147,53 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 	staticPropertiesIndex := len(columns) // where static properties start
 	// static properties are varchars
 	for _, property := range rc.StaticProperties {
-		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar NOT NULL DEFAULT '';", schema, resource, property)
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar DEFAULT NULL;", schema, resource, property)
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ALTER COLUMN \"%s\" DROP NOT NULL;", schema, resource, property) // compatibility with schemata <= 4
 		columns = append(columns, property)
 	}
 
 	// static searchable properties are varchars with a non-unique index
 	for _, property := range rc.SearchableProperties {
-		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar NOT NULL DEFAULT '';", schema, resource, property)
-		createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s);",
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar DEFAULT NULL;", schema, resource, property)
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ALTER COLUMN \"%s\" DROP NOT NULL;", schema, resource, property) // compatibility with schemata <= 4
+		createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"searchable_property_"+this+"_"+property,
-			schema, resource, property)
-		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s);",
+			schema, resource, property, property, property)
+		if len(majorSearchColumns) > 0 {
+			createIndicesQuery += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s\"(%s,%s) WHERE %s IS NOT NULL AND %s <> '';",
+				"searchable_property_"+this+"_"+property+"_"+strings.Join(majorSearchColumns, "_"),
+				schema, resource, property, strings.Join(majorSearchColumns, ","), property, property)
+		}
+		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
 			"searchable_property_"+this+"_"+property,
-			schema, resource, property)
+			schema, resource, property, property, property)
+		if len(majorSearchColumns) > 0 {
+			createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s,%s) WHERE %s IS NOT NULL AND %s <> '';",
+				"searchable_property_"+this+"_"+property+"_"+strings.Join(majorSearchColumns, "_"),
+				schema, resource, property, strings.Join(majorSearchColumns, ","), property, property)
+		}
 		columns = append(columns, property)
 		searchableColumns = append(searchableColumns, property)
 	}
 
-	propertiesEndIndex := len(columns) // where properties end
-
 	// an external index is a unique varchar property.
 	if len(rc.ExternalIndex) > 0 {
 		name := rc.ExternalIndex
-		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar NOT NULL DEFAULT '';", schema, resource, name)
-		createIndicesQuery += fmt.Sprintf("CREATE UNIQUE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s <> '';",
-			"external_index_"+this+"_"+name,
-			schema, resource, name, name)
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ADD COLUMN IF NOT EXISTS \"%s\" varchar DEFAULT NULL;", schema, resource, name)
+		createPropertiesQuery += fmt.Sprintf("ALTER TABLE %s.\"%s\" ALTER COLUMN \"%s\" DROP NOT NULL;", schema, resource, name) // compatibility with schemata <= 4
+		createIndicesQuery += fmt.Sprintf("DROP index IF EXISTS %s;", "external_index_"+this+"_"+name)
+		createIndicesQuery += fmt.Sprintf("CREATE UNIQUE index IF NOT EXISTS %s ON %s.\"%s\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
+			"unique_property_"+this+"_"+name,
+			schema, resource, name, name, name)
 		// the log index is not unique
-		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s);",
-			"external_index_"+this+"_"+name,
-			schema, resource, name)
+		createIndicesQueryLog += fmt.Sprintf("CREATE index IF NOT EXISTS %s ON %s.\"%s/log\"(%s) WHERE %s IS NOT NULL AND %s <> '';",
+			"unique_property_"+this+"_"+name,
+			schema, resource, name, name, name)
 		columns = append(columns, name)
 		searchableColumns = append(searchableColumns, name)
 	}
+
+	propertiesEndIndex := len(columns) // where properties end
 
 	// the "device" collection gets an additional UUID column for the web token
 	if this == "device" {
@@ -302,9 +317,9 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 		i++
 
 		for ; i < len(columns); i++ {
-			str := ""
-			values[i] = &str
-			object[columns[i]] = values[i]
+			nullStr := &sql.NullString{}
+			values[i] = nullStr
+			object[columns[i]] = nullStr
 
 		}
 
@@ -315,6 +330,20 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 		object["revision"] = revision
 		values = append(values, extra...)
 		return values, object
+	}
+
+	normalizeNullableStrings := func(object map[string]interface{}) {
+		for key, value := range object {
+			nullStr, ok := value.(*sql.NullString)
+			if !ok {
+				continue
+			}
+			if nullStr.Valid {
+				object[key] = nullStr.String
+			} else {
+				object[key] = nil
+			}
+		}
 	}
 
 	createScanValuesAndObjectMeta := func(timestamp *time.Time, revision *int, extra ...interface{}) ([]interface{}, map[string]interface{}) {
@@ -726,6 +755,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 					object["companion_download_url"] = uploadURL
 				}
 
+				normalizeNullableStrings(object)
 				mergeProperties(object)
 				// apply defaults if applicable
 				if rc.Default != nil {
@@ -888,6 +918,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 			http.Error(w, "Error 4727", status)
 			return
 		}
+		normalizeNullableStrings(object)
 		mergeProperties(object)
 
 		// apply defaults if applicable
@@ -1120,6 +1151,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 			}
 		}
 
+		normalizeNullableStrings(object)
 		mergeProperties(object)
 		jsonData, _ := json.MarshalWithOption(object, json.DisableHTMLEscape())
 
@@ -1542,7 +1574,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 		for ; i < len(columns); i++ {
 			value, ok := bodyJSON[columns[i]]
 			if !ok {
-				value = ""
+				value = nil
 			}
 			values[i] = value
 		}
@@ -1636,6 +1668,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 			}
 		}
 
+		normalizeNullableStrings(object)
 		mergeProperties(object)
 		jsonData, _ = json.MarshalWithOption(object, json.DisableHTMLEscape())
 
@@ -1788,6 +1821,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 		if revision >= 0 && revision != currentRevision {
 			tx.Rollback()
 			// revision does not match, return conflict status with the conflicting object
+			normalizeNullableStrings(object)
 			mergeProperties(object)
 			jsonData, _ := json.MarshalWithOption(object, json.DisableHTMLEscape())
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -1840,6 +1874,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 		if revision >= 0 && revision != currentRevision {
 			tx.Rollback()
 			// revision does not match, return conflict status with the conflicting object
+			normalizeNullableStrings(object)
 			mergeProperties(object)
 			jsonData, _ := json.MarshalWithOption(object, json.DisableHTMLEscape())
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -1847,6 +1882,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 			w.Write(jsonData)
 			return
 		}
+		normalizeNullableStrings(object)
 		mergeProperties(object)
 
 		// for MethodPatch we get the existing object from the database and patch property by property
@@ -1970,7 +2006,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 
 		for ; i < len(columns); i++ {
 			value, ok := bodyJSON[columns[i]]
-			if !ok {
+			if !ok && i < staticPropertiesIndex { // static properties and external indices are non mandatory, we can update them to null
 				tx.Rollback()
 				http.Error(w, "missing property or index "+columns[i], http.StatusBadRequest)
 				return
@@ -2014,6 +2050,7 @@ func (b *Backend) createRelationResource(router *mux.Router, rc RelationConfigur
 			http.Error(w, "Error 4740", http.StatusInternalServerError)
 			return
 		}
+		normalizeNullableStrings(response)
 		mergeProperties(response)
 		jsonData, _ = json.MarshalWithOption(response, json.DisableHTMLEscape())
 

--- a/core/backend/utils_test.go
+++ b/core/backend/utils_test.go
@@ -54,6 +54,8 @@ func createTestServiceInternal(config, schemaName string, clearSchema bool) *Tes
 		DB:                   s.Db,
 		Router:               s.Router,
 		AuthorizationEnabled: true,
+		JSONSchemas:          []string{schemaWorkoutString},
+		JSONSchemasRefs:      []string{schemaRefString},
 		UpdateSchema:         true,
 		KssConfiguration: kss.Configuration{
 			DriverType: kss.DriverTypeLocal,


### PR DESCRIPTION
Updated collection schema generation so static properties, searchable properties, and external index columns are nullable.

Adjusted searchable/external index creation to use partial indexes only for values that are not null and not empty strings.

Added null-safe handling in read/list response mapping so nullable string fields are scanned and serialized correctly.